### PR TITLE
feat(config): 添加手动可食用物品数据库和安全校验功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,31 @@ After waking up from sleep, the player will lose food level proportionally to th
 
 ### 3.睡眠
 睡醒后将移除睡眠时间相应的玩家饱食度
+### 4. 手动可吃物品数据库与指令
+
+服务器会创建并读取：`config/spiceoflifelatiao/edible_items.json`。
+这个文件用于保存管理员手动添加的可吃物品，避免再去世界存档里的隐藏附件数据中查找和手改。
+
+新增配置项：
+
+- `enable_auto_block_food_collect`：是否继续自动学习/记录方块食物。遇到非食物被误判可关闭。
+- `enable_manual_food_file`：是否启用上面的 JSON 手动数据库。
+- `enable_food_id_safety_check`：是否启用物品注册名安全校验。默认开启，防止 hash/旧缓存误判；如果希望保留作者原本“命中缓存就可吃”的宽松逻辑，可以关闭。
+
+常用指令（需要 OP 权限 2）：
+
+- `/sol_latiao food path`：查看 JSON 配置文件位置。
+- `/sol_latiao food list current [页码]`：查看当前世界可吃名单，包含原版、手动、自动学习条目。
+- `/sol_latiao food list all [页码]`：查看所有已加载世界的手动/自动学习条目，兼容多世界加载场景。
+- `/sol_latiao food show current <物品ID>`：查看当前世界某个物品的原版、手动、自动学习配置。
+- `/sol_latiao food add current <物品ID> <饱食度> <饱和度> [食用秒数]`：给当前世界添加手动可吃物品。
+- `/sol_latiao food add global <物品ID> <饱食度> <饱和度> [食用秒数]`：添加全局手动可吃物品。
+- `/sol_latiao food set current <物品ID> nutrition|saturation|eatSeconds|canAlwaysEat|usingConvertsTo|bites|bitesOffset|bitesType <值>`：修改当前世界条目。
+- `/sol_latiao food effect add current <物品ID> <效果ID> <持续tick> <等级> [概率]`：添加食后效果。
+- `/sol_latiao food effect remove current <物品ID> <效果ID>`：删除指定效果。
+- `/sol_latiao food effect clear current <物品ID>`：清空效果。
+- `/sol_latiao food remove current <物品ID>`：删除当前世界手动条目。
+- `/sol_latiao food reload` / `/sol_latiao food save`：重载/保存 JSON。
+- `/sol_latiao food importLegacy current|all`：把旧的隐藏世界附件条目尽量导入到 JSON 文件，方便后续维护。
+
+`/spiceoflifelatiao food ...` 也可以作为同义指令使用。

--- a/src/main/java/com/xdw/spiceoflifelatiao/Config.java
+++ b/src/main/java/com/xdw/spiceoflifelatiao/Config.java
@@ -59,6 +59,19 @@ public class Config {
             .comment("启用食用时间调整")
             .define("enable_eat_seconds",true);
 
+    public static final ModConfigSpec.ConfigValue<Boolean> ENABLE_AUTO_BLOCK_FOOD_COLLECT = BUILDER
+            .comment("启用自动学习/记录方块食物。关闭后不会再把交互过的方块写入隐藏世界附件，也不会信任旧的未标识条目，建议用 /sol_latiao food add 手动添加。")
+            .define("enable_auto_block_food_collect", true);
+
+    public static final ModConfigSpec.ConfigValue<Boolean> ENABLE_MANUAL_FOOD_FILE = BUILDER
+            .comment("启用 config/spiceoflifelatiao/edible_items.json 手动可食用物品数据库。")
+            .define("enable_manual_food_file", true);
+
+    public static final ModConfigSpec.ConfigValue<Boolean> ENABLE_FOOD_ID_SAFETY_CHECK = BUILDER
+            .comment("启用可食用物品 ID 安全校验。开启时，隐藏世界附件中的 hash 必须同时匹配物品注册名，防止 hash 碰撞或旧缓存让原石等非食物误判为可吃。")
+            .comment("如果希望保留作者原本的宽松逻辑，允许仅凭旧 hash/缓存让更多物品可吃，可以关闭此项。")
+            .define("enable_food_id_safety_check", true);
+
     public static final ModConfigSpec.ConfigValue<Integer> HISTORY_LENGTH_LONG = BUILDER
             .comment("用于统计长期饮食数据")
             .defineInRange("historyLengthLong", 512, 0, 65535);

--- a/src/main/java/com/xdw/spiceoflifelatiao/SpiceOfLifeLatiao.java
+++ b/src/main/java/com/xdw/spiceoflifelatiao/SpiceOfLifeLatiao.java
@@ -3,28 +3,38 @@ package com.xdw.spiceoflifelatiao;
 import com.xdw.spiceoflifelatiao.attachments.ModAttachments;
 import com.xdw.spiceoflifelatiao.cached.ConfigCached;
 import com.xdw.spiceoflifelatiao.event.LevelEventHandle;
+import com.xdw.spiceoflifelatiao.event.ManualFoodComponentEvent;
 import com.xdw.spiceoflifelatiao.event.PlayerEventHandle;
 import com.xdw.spiceoflifelatiao.linkage.FoodItemEvent;
 import com.xdw.spiceoflifelatiao.network.SyncHandler;
+import com.xdw.spiceoflifelatiao.command.FoodCommand;
+import com.xdw.spiceoflifelatiao.config.ManualFoodConfig;
+import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.config.ModConfig;
 import net.neoforged.neoforge.common.NeoForge;
+import org.slf4j.Logger;
+import com.mojang.logging.LogUtils;
 
 @Mod(SpiceOfLifeLatiao.MODID)
 public class SpiceOfLifeLatiao {
     public static final String MODID = "spiceoflifelatiao";
     public static final String VERSION = "1.3.3";
+    public static final Logger LOGGER = LogUtils.getLogger();
 
     public SpiceOfLifeLatiao(IEventBus modEventBus, ModContainer modContainer) {
         modEventBus.addListener(SyncHandler::onRegisterPayloadHandler);
+        modEventBus.addListener(EventPriority.LOWEST, ManualFoodComponentEvent::modifyDefaultComponents);
         modEventBus.addListener(ConfigCached::onConfigLoaded);
         modEventBus.addListener(ConfigCached::onConfigReload);
         ModAttachments.ATTACHMENTS.register(modEventBus);
         NeoForge.EVENT_BUS.register(LevelEventHandle.class);
         NeoForge.EVENT_BUS.register(PlayerEventHandle.class);
         NeoForge.EVENT_BUS.register(FoodItemEvent.class);
+        NeoForge.EVENT_BUS.register(FoodCommand.class);
+        ManualFoodConfig.load();
         modContainer.registerConfig(ModConfig.Type.SERVER, Config.SPEC);
     }
 }

--- a/src/main/java/com/xdw/spiceoflifelatiao/attachments/LevelOrgFoodValue.java
+++ b/src/main/java/com/xdw/spiceoflifelatiao/attachments/LevelOrgFoodValue.java
@@ -3,6 +3,8 @@ package com.xdw.spiceoflifelatiao.attachments;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.xdw.spiceoflifelatiao.SpiceOfLifeLatiao;
+import com.xdw.spiceoflifelatiao.cached.ConfigCached;
+import com.xdw.spiceoflifelatiao.config.ManualFoodConfig;
 import com.xdw.spiceoflifelatiao.util.EatFormulaContext;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -32,23 +34,48 @@ public final class LevelOrgFoodValue {
     public final Map<Integer, Integer> bitesOffset = new HashMap<>();
     public final Map<Integer, Integer> bitesType = new HashMap<>();
     public final Map<Integer, ResourceLocation> usingConvertsTo = new HashMap<>();
+    /** Hash -> registry id. This prevents unrelated items from becoming edible because of 32-bit hash collisions. */
+    public final Map<Integer, ResourceLocation> itemIds = new HashMap<>();
 
     public static int getFoodHash(Item item, Integer bite) {
+        ResourceLocation itemId = BuiltInRegistries.ITEM.getKey(item);
+        String id = itemId == null ? item.toString().replace(" ", "") : itemId.toString();
+        return (SpiceOfLifeLatiao.VERSION + ":" + id + ":" + (bite != null ? bite : "")).hashCode();
+    }
+
+    public static int getLegacyFoodHash(Item item, Integer bite) {
         return (SpiceOfLifeLatiao.VERSION + ":" + item.toString().replace(" ", "") + ":" + (bite != null ? bite : "")).hashCode();
     }
 
+    public static boolean isTrusted(LevelOrgFoodValue data, Item item, Integer bite) {
+        int hash = getFoodHash(item, bite);
+        if (!data.hash.contains(hash)) return false;
+        if (!ConfigCached.ENABLE_FOOD_ID_SAFETY_CHECK) return true;
+        ResourceLocation itemId = BuiltInRegistries.ITEM.getKey(item);
+        return itemId != null && itemId.equals(data.itemIds.get(hash));
+    }
+
+    public static void markTrusted(LevelOrgFoodValue data, Item item, Integer bite) {
+        ResourceLocation itemId = BuiltInRegistries.ITEM.getKey(item);
+        if (itemId != null) data.itemIds.put(getFoodHash(item, bite), itemId);
+    }
+
     public static Vec3 getBlockFoodInfo(@NotNull Player player, @NotNull ItemStack stack, Integer bite, FoodProperties _defaultFoodInfo, boolean sliceCalc, int flag) {
-        Optional<FoodProperties> defInfo = Optional.ofNullable(_defaultFoodInfo);
+        Optional<ManualFoodConfig.Entry> manualEntry = ConfigCached.ENABLE_MANUAL_FOOD_FILE ? ManualFoodConfig.getEntry(player.level(), stack.getItem()) : Optional.empty();
+        Optional<FoodProperties> defInfo = Optional.ofNullable(_defaultFoodInfo)
+                .or(() -> manualEntry.flatMap(entry -> entry.toFoodProperties(null)));
         if (!player.isAddedToLevel() || player.tickCount <= 0)
             return defInfo.map(it -> new Vec3(it.nutrition(), it.saturation(), it.eatSeconds())).orElse(new Vec3(0, 0, 1.6F));
-        LevelOrgFoodValue data = sliceCalc ? player.level().getData(ModAttachments.LEVEL_ORG_FOOD_VALUE) : new LevelOrgFoodValue();
+        LevelOrgFoodValue storedData = sliceCalc ? player.level().getData(ModAttachments.LEVEL_ORG_FOOD_VALUE) : new LevelOrgFoodValue();
         int defHash = LevelOrgFoodValue.getFoodHash(stack.getItem(), null);
-        Optional<Integer> bites = Optional.ofNullable(data.bites.get(defHash));
-        Optional<Integer> bitesOffset = Optional.ofNullable(data.bitesOffset.get(defHash));
-        Optional<Integer> bitesType = Optional.ofNullable(data.bitesType.get(defHash));
+        boolean trustedStoredFood = sliceCalc && isTrusted(storedData, stack.getItem(), null);
+        final LevelOrgFoodValue data = (sliceCalc && !trustedStoredFood && manualEntry.isEmpty()) ? new LevelOrgFoodValue() : storedData;
+        Optional<Integer> bites = manualEntry.map(entry -> entry.bites).filter(Objects::nonNull).or(() -> Optional.ofNullable(data.bites.get(defHash)));
+        Optional<Integer> bitesOffset = manualEntry.map(entry -> entry.bitesOffset).filter(Objects::nonNull).or(() -> Optional.ofNullable(data.bitesOffset.get(defHash)));
+        Optional<Integer> bitesType = manualEntry.map(entry -> entry.bitesType).filter(Objects::nonNull).or(() -> Optional.ofNullable(data.bitesType.get(defHash)));
         Optional<Integer> itemFoodBites = bites;
         bite = bite == null ? (bitesType.isPresent() && bitesType.get() == 1 ? bites.orElse(0) : 0) : bite;
-        if (sliceCalc && !data.hash.contains(defHash) && stack.getItem() instanceof BlockItem bi) {
+        if (sliceCalc && ConfigCached.ENABLE_AUTO_BLOCK_FOOD_COLLECT && manualEntry.isEmpty() && !trustedStoredFood && stack.getItem() instanceof BlockItem bi) {
             BlockState blockState = bi.getBlock().defaultBlockState();
             itemFoodBites = blockState.getValues().keySet().stream().map(comparable -> {
                 if (comparable instanceof IntegerProperty ip && ip.getName().equals("bites")) {
@@ -66,11 +93,13 @@ public final class LevelOrgFoodValue {
 
         int finalBites = itemFoodBites.orElse(1);
 
-        var hash0 = LevelOrgFoodValue.getFoodHash(stack.getItem(),bitesType.isPresent() && bitesType.get() == 1 ? finalBites : 0);
-        var hunger_direct_def = Optional.ofNullable(data.hunger.get(hash0));
-        var saturation_direct_def = Optional.ofNullable(data.saturation.get(hash0));
+        var hash0Bite = bitesType.isPresent() && bitesType.get() == 1 ? finalBites : 0;
+        var hash0 = LevelOrgFoodValue.getFoodHash(stack.getItem(), hash0Bite);
+        var trustedHash0 = manualEntry.isPresent() || isTrusted(data, stack.getItem(), hash0Bite);
+        var hunger_direct_def = trustedHash0 ? Optional.ofNullable(data.hunger.get(hash0)) : Optional.<Float>empty();
+        var saturation_direct_def = trustedHash0 ? Optional.ofNullable(data.saturation.get(hash0)) : Optional.<Float>empty();
 
-        var packInfo_def = Optional.ofNullable(data.usingConvertsTo.get(hash0))
+        var packInfo_def = (trustedHash0 ? Optional.ofNullable(data.usingConvertsTo.get(hash0)) : Optional.<ResourceLocation>empty())
                 .map(BuiltInRegistries.ITEM::get)
                 .map(i -> i.getDefaultInstance().get(DataComponents.FOOD))
                 .map(i -> new Vec3(i.nutrition(), i.saturation(), 0));
@@ -86,7 +115,8 @@ public final class LevelOrgFoodValue {
                             var tileHunger = 0;
                             var tileSaturation = 0F;
                             var hashIt = LevelOrgFoodValue.getFoodHash(stack.getItem(), it);
-                            Optional<ItemStack> packFood = Optional.ofNullable(data.usingConvertsTo.get(hashIt))
+                            boolean trustedHashIt = manualEntry.isPresent() || isTrusted(data, stack.getItem(), it);
+                            Optional<ItemStack> packFood = (trustedHashIt ? Optional.ofNullable(data.usingConvertsTo.get(hashIt)) : Optional.<ResourceLocation>empty())
                                     .map(BuiltInRegistries.ITEM::get)
                                     .map(Item::getDefaultInstance);
                             Optional<Vec3> packInfo = packFood
@@ -94,8 +124,8 @@ public final class LevelOrgFoodValue {
                                     .map(i -> new Vec3(i.nutrition(), i.saturation(), 0));
                             var hunger_def = defInfo.map(FoodProperties::nutrition).map(i -> sliceCalc ? i / (float) finalBites : i);
                             var saturation_def = defInfo.map(FoodProperties::saturation).map(i -> sliceCalc ? i / (float) finalBites : i);
-                            var hunger_direct = Optional.ofNullable(data.hunger.get(hashIt));
-                            var saturation_direct = Optional.ofNullable(data.saturation.get(hashIt));
+                            var hunger_direct = trustedHashIt ? Optional.ofNullable(data.hunger.get(hashIt)) : Optional.<Float>empty();
+                            var saturation_direct = trustedHashIt ? Optional.ofNullable(data.saturation.get(hashIt)) : Optional.<Float>empty();
                             var hunger_pack = packInfo.map(i -> (float) i.x);
                             var saturation_pack = packInfo.map(i -> (float) i.y);
                             var onlyPackInfo = defInfo.isEmpty() && hunger_direct.isEmpty() && (packInfo.isPresent() || packInfo_def.isPresent());
@@ -125,9 +155,10 @@ public final class LevelOrgFoodValue {
     }
 
     public static Optional<Integer> getInfoFinishState(@NotNull Player player, @NotNull ItemStack stack) {
+        if (ConfigCached.ENABLE_MANUAL_FOOD_FILE && ManualFoodConfig.getEntry(player.level(), stack.getItem()).isPresent()) return Optional.of(2);
         var data = player.level().getData(ModAttachments.LEVEL_ORG_FOOD_VALUE);
         var defHash = LevelOrgFoodValue.getFoodHash(stack.getItem(),null);
-        if(!data.hash.contains(defHash)) return Optional.empty();
+        if(!isTrusted(data, stack.getItem(), null)) return Optional.empty();
         if (data.bitesType.get(defHash) instanceof Integer type
                 && data.bites.get(defHash) instanceof Integer bites
                 && data.bitesOffset.get(defHash) instanceof Integer offset
@@ -165,8 +196,9 @@ public final class LevelOrgFoodValue {
             CustomCodec.INT_INT_MAP.fieldOf("bites").forGetter(v -> v.bites),
             CustomCodec.INT_INT_MAP.fieldOf("bitesOffset").forGetter(v -> v.bitesOffset),
             CustomCodec.INT_INT_MAP.fieldOf("bitesType").forGetter(v -> v.bitesType),
-            CustomCodec.INT_RL_MAP.fieldOf("usingConvertsTo").forGetter(v -> v.usingConvertsTo)
-    ).apply(i, (a, b, c, d, f, g,h) -> {
+            CustomCodec.INT_RL_MAP.fieldOf("usingConvertsTo").forGetter(v -> v.usingConvertsTo),
+            CustomCodec.INT_RL_MAP.optionalFieldOf("itemIds", Map.<Integer, ResourceLocation>of()).forGetter(v -> v.itemIds)
+    ).apply(i, (a, b, c, d, f, g,h, ids) -> {
         LevelOrgFoodValue v = new LevelOrgFoodValue();
         v.hash.addAll(a);
         v.hunger.putAll(b);
@@ -175,6 +207,7 @@ public final class LevelOrgFoodValue {
         v.bitesOffset.putAll(f);
         v.bitesType.putAll(g);
         v.usingConvertsTo.putAll(h);
+        v.itemIds.putAll(ids);
         return v;
     }));
 
@@ -218,6 +251,12 @@ public final class LevelOrgFoodValue {
             b.writeVarInt(k);
             ResourceLocation.STREAM_CODEC.encode(b, f);
         });
+
+        b.writeVarInt(v.itemIds.size());
+        v.itemIds.forEach((k, f) -> {
+            b.writeVarInt(k);
+            ResourceLocation.STREAM_CODEC.encode(b, f);
+        });
     }, b -> {
         LevelOrgFoodValue v = new LevelOrgFoodValue();
 
@@ -241,6 +280,9 @@ public final class LevelOrgFoodValue {
 
         for (int i = b.readVarInt(); i-- > 0; )
             v.usingConvertsTo.put(b.readVarInt(), ResourceLocation.STREAM_CODEC.decode(b));
+
+        for (int i = b.readVarInt(); i-- > 0; )
+            v.itemIds.put(b.readVarInt(), ResourceLocation.STREAM_CODEC.decode(b));
 
         return v;
     });

--- a/src/main/java/com/xdw/spiceoflifelatiao/cached/ConfigCached.java
+++ b/src/main/java/com/xdw/spiceoflifelatiao/cached/ConfigCached.java
@@ -16,6 +16,9 @@ public final class ConfigCached {
     public static boolean EANBLE_HUNGER = false;
     public static boolean EANBLE_SATURATION = false;
     public static boolean EANBLE_EAT_SECONDS = false;
+    public static boolean ENABLE_AUTO_BLOCK_FOOD_COLLECT = true;
+    public static boolean ENABLE_MANUAL_FOOD_FILE = true;
+    public static boolean ENABLE_FOOD_ID_SAFETY_CHECK = true;
     public static int HISTORY_LENGTH_LONG = 512;
     public static int HISTORY_LENGTH_SHORT = 16;
     public static List<? extends String> LOSS = List.of("0");
@@ -44,6 +47,9 @@ public final class ConfigCached {
         EANBLE_HUNGER = Config.EANBLE_HUNGER.get();
         EANBLE_SATURATION = Config.EANBLE_SATURATION.get();
         EANBLE_EAT_SECONDS = Config.EANBLE_EAT_SECONDS.get();
+        ENABLE_AUTO_BLOCK_FOOD_COLLECT = Config.ENABLE_AUTO_BLOCK_FOOD_COLLECT.get();
+        ENABLE_MANUAL_FOOD_FILE = Config.ENABLE_MANUAL_FOOD_FILE.get();
+        ENABLE_FOOD_ID_SAFETY_CHECK = Config.ENABLE_FOOD_ID_SAFETY_CHECK.get();
         HISTORY_LENGTH_LONG = Config.HISTORY_LENGTH_LONG.get();
         HISTORY_LENGTH_SHORT = Config.HISTORY_LENGTH_SHORT.get();
         LOSS = Config.LOSS.get();

--- a/src/main/java/com/xdw/spiceoflifelatiao/cached/FoodDataCached.java
+++ b/src/main/java/com/xdw/spiceoflifelatiao/cached/FoodDataCached.java
@@ -32,6 +32,16 @@ public class FoodDataCached {
     public static Optional<Integer> bite = Optional.empty();
     public static Optional<Integer> type = Optional.empty();
     public static Optional<ItemStack> usingConvertsTo = Optional.empty();
+    /**
+     * Farmer's Delight FeastBlock takeServing 会把盛出的食物塞进玩家背包。
+     * 这里临时捕获 Inventory.add 接收到的 ItemStack，用于记录 serving 后转换物品。
+     *
+     * 之前这段状态放在 linkage.farmersdelight.FeastBlockCached 中。
+     * 一些服务器/构建方式可能没有把该辅助类打进最终 jar，导致运行时 NoClassDefFoundError。
+     * 放到 FoodDataCached 里可以避免额外辅助类缺失导致服务器在玩家拾取物品时崩溃。
+     */
+    public static boolean feastBlockServingCapture = false;
+    public static Optional<ItemStack> feastBlockTakeServing = Optional.empty();
     public static Optional<FoodProperties> foodProperties = Optional.empty();
     public static Optional<Integer> addHunger = Optional.empty();
     public static Optional<Float> addSaturation = Optional.empty();
@@ -46,6 +56,21 @@ public class FoodDataCached {
         player = _player;
         item = _item;
     }
+    public static void startFeastBlockServingCapture() {
+        feastBlockServingCapture = true;
+        feastBlockTakeServing = Optional.empty();
+    }
+
+    public static void endFeastBlockServingCapture() {
+        feastBlockServingCapture = false;
+        feastBlockTakeServing = Optional.empty();
+    }
+
+    public static void captureFeastBlockServing(ItemStack stack) {
+        if (!feastBlockServingCapture || stack == null || stack.isEmpty()) return;
+        feastBlockTakeServing = Optional.of(stack.copy());
+    }
+
     public static void end(){
 //        添加饮食记录 一般饮食行为
         if (player.isPresent() && player.get() instanceof ServerPlayer serverPlayer && serverPlayer.getFoodData() instanceof IEatHistoryAcessor acc && item.isPresent() && realHunger.isPresent() && realSaturation.isPresent()) {
@@ -53,8 +78,8 @@ public class FoodDataCached {
             PacketDistributor.sendToPlayer(serverPlayer, new AddEatHistoryMsg(foodHash, (float) realHunger.get(), realSaturation.get(), 1.0f / (float) bites.orElse(1), hungerRoundErr.orElse(0F)));
             acc.addEatHistory_Mem(foodHash, (float) realHunger.get(), realSaturation.get(), 1.0f / (float) bites.orElse(1), hungerRoundErr.orElse(0F));
         }
-//            方块食物与分装食物
-        if (player.isPresent() && item.isPresent() && bite.isPresent() && bites.isPresent()) {
+//            方块食物与分装食物（自动学习/记录可关闭，避免把误判数据继续写进世界附件）
+        if (ConfigCached.ENABLE_AUTO_BLOCK_FOOD_COLLECT && player.isPresent() && item.isPresent() && bite.isPresent() && bites.isPresent()) {
             var defHash = LevelOrgFoodValue.getFoodHash(item.get().getItem(), null);
             var curHash = LevelOrgFoodValue.getFoodHash(item.get().getItem(), bite.get());
             var level = player.get().level();
@@ -69,6 +94,14 @@ public class FoodDataCached {
             }
             if (!data.hash.contains(curHash)) {
                 data.hash.add(curHash);
+                isChanged.set(true);
+            }
+            if (!Objects.equals(data.itemIds.get(defHash), BuiltInRegistries.ITEM.getKey(item.get().getItem()))) {
+                LevelOrgFoodValue.markTrusted(data, item.get().getItem(), null);
+                isChanged.set(true);
+            }
+            if (!Objects.equals(data.itemIds.get(curHash), BuiltInRegistries.ITEM.getKey(item.get().getItem()))) {
+                LevelOrgFoodValue.markTrusted(data, item.get().getItem(), bite.get());
                 isChanged.set(true);
             }
 
@@ -168,6 +201,8 @@ public class FoodDataCached {
         bite = Optional.empty();
         type = Optional.empty();
         usingConvertsTo = Optional.empty();
+        feastBlockServingCapture = false;
+        feastBlockTakeServing = Optional.empty();
         foodProperties = Optional.empty();
         addHunger = Optional.empty();
         addSaturation = Optional.empty();

--- a/src/main/java/com/xdw/spiceoflifelatiao/command/FoodCommand.java
+++ b/src/main/java/com/xdw/spiceoflifelatiao/command/FoodCommand.java
@@ -1,0 +1,664 @@
+package com.xdw.spiceoflifelatiao.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.arguments.FloatArgumentType;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.xdw.spiceoflifelatiao.attachments.LevelOrgFoodValue;
+import com.xdw.spiceoflifelatiao.attachments.ModAttachments;
+import com.xdw.spiceoflifelatiao.config.ManualFoodConfig;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.ResourceLocationArgument;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.food.FoodProperties;
+import net.minecraft.world.item.Item;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+public final class FoodCommand {
+    private static final int PAGE_SIZE = 8;
+
+    private FoodCommand() {}
+
+    @SubscribeEvent
+    public static void register(RegisterCommandsEvent event) {
+        registerRoot(event.getDispatcher(), "sol_latiao");
+        registerRoot(event.getDispatcher(), "spiceoflifelatiao");
+    }
+
+    private static void registerRoot(CommandDispatcher<CommandSourceStack> dispatcher, String name) {
+        dispatcher.register(Commands.literal(name)
+                .requires(source -> source.hasPermission(2))
+                .then(Commands.literal("food")
+                        .then(Commands.literal("path").executes(ctx -> path(ctx.getSource())))
+                        .then(Commands.literal("reload").executes(ctx -> reload(ctx.getSource())))
+                        .then(Commands.literal("save").executes(ctx -> save(ctx.getSource())))
+                        .then(Commands.literal("list")
+                                .then(Commands.literal("current")
+                                        .executes(ctx -> listCurrent(ctx.getSource(), 1))
+                                        .then(Commands.argument("page", IntegerArgumentType.integer(1))
+                                                .executes(ctx -> listCurrent(ctx.getSource(), IntegerArgumentType.getInteger(ctx, "page")))))
+                                .then(Commands.literal("global")
+                                        .executes(ctx -> listGlobal(ctx.getSource(), 1))
+                                        .then(Commands.argument("page", IntegerArgumentType.integer(1))
+                                                .executes(ctx -> listGlobal(ctx.getSource(), IntegerArgumentType.getInteger(ctx, "page")))))
+                                .then(Commands.literal("all")
+                                        .executes(ctx -> listAll(ctx.getSource(), 1))
+                                        .then(Commands.argument("page", IntegerArgumentType.integer(1))
+                                                .executes(ctx -> listAll(ctx.getSource(), IntegerArgumentType.getInteger(ctx, "page"))))))
+                        .then(Commands.literal("show")
+                                .then(Commands.literal("current").then(itemArg("item").executes(ctx -> show(ctx.getSource(), ctx.getSource().getLevel(), itemId(ctx, "item")))))
+                                .then(Commands.literal("global").then(itemArg("item").executes(ctx -> showGlobal(ctx.getSource(), itemId(ctx, "item")))))
+                                .then(Commands.literal("all").then(itemArg("item").executes(ctx -> showAll(ctx.getSource(), itemId(ctx, "item"))))))
+                        .then(Commands.literal("add")
+                                .then(Commands.literal("current").then(addArgs(false)))
+                                .then(Commands.literal("global").then(addArgs(true))))
+                        .then(Commands.literal("remove")
+                                .then(Commands.literal("current").then(itemArg("item").executes(ctx -> remove(ctx.getSource(), ctx.getSource().getLevel().dimension().location(), itemId(ctx, "item")))))
+                                .then(Commands.literal("global").then(itemArg("item").executes(ctx -> remove(ctx.getSource(), null, itemId(ctx, "item"))))))
+                        .then(Commands.literal("set")
+                                .then(Commands.literal("current").then(setArgs(false)))
+                                .then(Commands.literal("global").then(setArgs(true))))
+                        .then(Commands.literal("effect")
+                                .then(Commands.literal("add")
+                                        .then(Commands.literal("current").then(effectAddArgs(false)))
+                                        .then(Commands.literal("global").then(effectAddArgs(true))))
+                                .then(Commands.literal("remove")
+                                        .then(Commands.literal("current").then(effectRemoveArgs(false)))
+                                        .then(Commands.literal("global").then(effectRemoveArgs(true))))
+                                .then(Commands.literal("clear")
+                                        .then(Commands.literal("current").then(itemArg("item").executes(ctx -> clearEffects(ctx.getSource(), ctx.getSource().getLevel().dimension().location(), itemId(ctx, "item")))))
+                                        .then(Commands.literal("global").then(itemArg("item").executes(ctx -> clearEffects(ctx.getSource(), null, itemId(ctx, "item")))))))
+                        .then(Commands.literal("importLegacy")
+                                .then(Commands.literal("current").executes(ctx -> importLegacyCurrent(ctx.getSource())))
+                                .then(Commands.literal("all").executes(ctx -> importLegacyAll(ctx.getSource()))))
+                ));
+    }
+
+    private static com.mojang.brigadier.builder.RequiredArgumentBuilder<CommandSourceStack, ResourceLocation> itemArg(String name) {
+        return Commands.argument(name, ResourceLocationArgument.id());
+    }
+
+    private static com.mojang.brigadier.builder.RequiredArgumentBuilder<CommandSourceStack, ResourceLocation> addArgs(boolean global) {
+        return itemArg("item")
+                .then(Commands.argument("nutrition", IntegerArgumentType.integer(0))
+                        .then(Commands.argument("saturation", FloatArgumentType.floatArg(0F))
+                                .executes(ctx -> add(ctx.getSource(), global ? null : ctx.getSource().getLevel().dimension().location(), itemId(ctx, "item"), IntegerArgumentType.getInteger(ctx, "nutrition"), FloatArgumentType.getFloat(ctx, "saturation"), 1.6F, null, null, null, null, null))
+                                .then(Commands.argument("eatSeconds", FloatArgumentType.floatArg(0.05F))
+                                        .executes(ctx -> add(ctx.getSource(), global ? null : ctx.getSource().getLevel().dimension().location(), itemId(ctx, "item"), IntegerArgumentType.getInteger(ctx, "nutrition"), FloatArgumentType.getFloat(ctx, "saturation"), FloatArgumentType.getFloat(ctx, "eatSeconds"), null, null, null, null, null))
+                                        .then(Commands.argument("canAlwaysEat", BoolArgumentType.bool())
+                                                .executes(ctx -> add(ctx.getSource(), global ? null : ctx.getSource().getLevel().dimension().location(), itemId(ctx, "item"), IntegerArgumentType.getInteger(ctx, "nutrition"), FloatArgumentType.getFloat(ctx, "saturation"), FloatArgumentType.getFloat(ctx, "eatSeconds"), BoolArgumentType.getBool(ctx, "canAlwaysEat"), null, null, null, null))
+                                                .then(itemArg("usingConvertsTo")
+                                                        .executes(ctx -> add(ctx.getSource(), global ? null : ctx.getSource().getLevel().dimension().location(), itemId(ctx, "item"), IntegerArgumentType.getInteger(ctx, "nutrition"), FloatArgumentType.getFloat(ctx, "saturation"), FloatArgumentType.getFloat(ctx, "eatSeconds"), BoolArgumentType.getBool(ctx, "canAlwaysEat"), rawId(ctx, "usingConvertsTo"), null, null, null))
+                                                        .then(Commands.argument("bites", IntegerArgumentType.integer(1))
+                                                                .executes(ctx -> add(ctx.getSource(), global ? null : ctx.getSource().getLevel().dimension().location(), itemId(ctx, "item"), IntegerArgumentType.getInteger(ctx, "nutrition"), FloatArgumentType.getFloat(ctx, "saturation"), FloatArgumentType.getFloat(ctx, "eatSeconds"), BoolArgumentType.getBool(ctx, "canAlwaysEat"), rawId(ctx, "usingConvertsTo"), IntegerArgumentType.getInteger(ctx, "bites"), null, null))
+                                                                .then(Commands.argument("bitesType", StringArgumentType.word())
+                                                                        .executes(ctx -> add(ctx.getSource(), global ? null : ctx.getSource().getLevel().dimension().location(), itemId(ctx, "item"), IntegerArgumentType.getInteger(ctx, "nutrition"), FloatArgumentType.getFloat(ctx, "saturation"), FloatArgumentType.getFloat(ctx, "eatSeconds"), BoolArgumentType.getBool(ctx, "canAlwaysEat"), rawId(ctx, "usingConvertsTo"), IntegerArgumentType.getInteger(ctx, "bites"), StringArgumentType.getString(ctx, "bitesType"), null))
+                                                                        .then(Commands.argument("bitesOffset", IntegerArgumentType.integer(0))
+                                                                                .executes(ctx -> add(ctx.getSource(), global ? null : ctx.getSource().getLevel().dimension().location(), itemId(ctx, "item"), IntegerArgumentType.getInteger(ctx, "nutrition"), FloatArgumentType.getFloat(ctx, "saturation"), FloatArgumentType.getFloat(ctx, "eatSeconds"), BoolArgumentType.getBool(ctx, "canAlwaysEat"), rawId(ctx, "usingConvertsTo"), IntegerArgumentType.getInteger(ctx, "bites"), StringArgumentType.getString(ctx, "bitesType"), IntegerArgumentType.getInteger(ctx, "bitesOffset")))))))))));
+    }
+
+    private static com.mojang.brigadier.builder.RequiredArgumentBuilder<CommandSourceStack, ResourceLocation> setArgs(boolean global) {
+        return itemArg("item")
+                .then(setNutritionLiteral(global, "nutrition"))
+                .then(setNutritionLiteral(global, "hunger"))
+                .then(setNutritionLiteral(global, "hungry"))
+                .then(Commands.literal("saturation").then(Commands.argument("value", FloatArgumentType.floatArg(0F)).executes(ctx -> setEntry(ctx.getSource(), global, itemId(ctx, "item"), e -> e.saturation = FloatArgumentType.getFloat(ctx, "value"), "saturation"))))
+                .then(Commands.literal("eatSeconds").then(Commands.argument("value", FloatArgumentType.floatArg(0.05F)).executes(ctx -> setEntry(ctx.getSource(), global, itemId(ctx, "item"), e -> e.eatSeconds = FloatArgumentType.getFloat(ctx, "value"), "eatSeconds"))))
+                .then(Commands.literal("canAlwaysEat").then(Commands.argument("value", BoolArgumentType.bool()).executes(ctx -> setEntry(ctx.getSource(), global, itemId(ctx, "item"), e -> e.canAlwaysEat = BoolArgumentType.getBool(ctx, "value"), "canAlwaysEat"))))
+                .then(Commands.literal("usingConvertsTo").then(itemArg("value").executes(ctx -> setConvert(ctx.getSource(), global, itemId(ctx, "item"), rawId(ctx, "value")))))
+                .then(Commands.literal("bites").then(Commands.argument("value", IntegerArgumentType.integer(1)).executes(ctx -> setEntry(ctx.getSource(), global, itemId(ctx, "item"), e -> e.bites = IntegerArgumentType.getInteger(ctx, "value"), "bites"))))
+                .then(Commands.literal("bitesOffset").then(Commands.argument("value", IntegerArgumentType.integer(0)).executes(ctx -> setEntry(ctx.getSource(), global, itemId(ctx, "item"), e -> e.bitesOffset = IntegerArgumentType.getInteger(ctx, "value"), "bitesOffset"))))
+                .then(Commands.literal("bitesType").then(Commands.argument("value", StringArgumentType.word()).executes(ctx -> setBitesType(ctx.getSource(), global, itemId(ctx, "item"), StringArgumentType.getString(ctx, "value")))));
+    }
+
+    private static com.mojang.brigadier.builder.LiteralArgumentBuilder<CommandSourceStack> setNutritionLiteral(boolean global, String literal) {
+        return Commands.literal(literal)
+                .then(Commands.argument("value", IntegerArgumentType.integer(0))
+                        .executes(ctx -> setEntry(ctx.getSource(), global, itemId(ctx, "item"), e -> e.nutrition = IntegerArgumentType.getInteger(ctx, "value"), literal)));
+    }
+
+    private static com.mojang.brigadier.builder.RequiredArgumentBuilder<CommandSourceStack, ResourceLocation> effectAddArgs(boolean global) {
+        return itemArg("item")
+                .then(itemArg("effect")
+                        .then(Commands.argument("durationTicks", IntegerArgumentType.integer(1))
+                                .then(Commands.argument("amplifier", IntegerArgumentType.integer(0))
+                                        .executes(ctx -> addEffect(ctx.getSource(), global, itemId(ctx, "item"), effectId(ctx, "effect"), IntegerArgumentType.getInteger(ctx, "durationTicks"), IntegerArgumentType.getInteger(ctx, "amplifier"), 1F))
+                                        .then(Commands.argument("probability", FloatArgumentType.floatArg(0F, 1F))
+                                                .executes(ctx -> addEffect(ctx.getSource(), global, itemId(ctx, "item"), effectId(ctx, "effect"), IntegerArgumentType.getInteger(ctx, "durationTicks"), IntegerArgumentType.getInteger(ctx, "amplifier"), FloatArgumentType.getFloat(ctx, "probability")))))));
+    }
+
+    private static com.mojang.brigadier.builder.RequiredArgumentBuilder<CommandSourceStack, ResourceLocation> effectRemoveArgs(boolean global) {
+        return itemArg("item")
+                .then(itemArg("effect").executes(ctx -> removeEffect(ctx.getSource(), global ? null : ctx.getSource().getLevel().dimension().location(), itemId(ctx, "item"), effectId(ctx, "effect"))));
+    }
+
+    private static String rawId(com.mojang.brigadier.context.CommandContext<CommandSourceStack> ctx, String name) {
+        return ResourceLocationArgument.getId(ctx, name).toString();
+    }
+
+    private static ResourceLocation itemId(com.mojang.brigadier.context.CommandContext<CommandSourceStack> ctx, String name) {
+        return resolveParsedId(ResourceLocationArgument.getId(ctx, name), ManualFoodConfig::isValidItem);
+    }
+
+    private static ResourceLocation effectId(com.mojang.brigadier.context.CommandContext<CommandSourceStack> ctx, String name) {
+        return resolveParsedId(ResourceLocationArgument.getId(ctx, name), ManualFoodConfig::isValidEffect);
+    }
+
+    private static ResourceLocation resolveId(String raw, Predicate<ResourceLocation> exists) {
+        String value = raw == null ? "" : raw.trim().toLowerCase(Locale.ROOT);
+        ResourceLocation direct = tryParseId(value);
+        if (direct == null) return ResourceLocation.parse(value);
+        return resolveParsedId(direct, exists);
+    }
+
+    private static ResourceLocation resolveParsedId(ResourceLocation parsed, Predicate<ResourceLocation> exists) {
+        if (parsed == null) return ResourceLocation.parse("");
+        if (exists.test(parsed)) return parsed;
+
+        // Vanilla's ResourceLocationArgument turns a bare word like "mekanism_canteen" into
+        // "minecraft:mekanism_canteen". Treat that minecraft path as an alias candidate.
+        if ("minecraft".equals(parsed.getNamespace())) {
+            ResourceLocation alias = resolveAlias(parsed.getPath(), exists);
+            if (alias != null) return alias;
+        }
+
+        // Also allow manually supplied raw strings to fall back through this method.
+        ResourceLocation alias = resolveAlias(parsed.toString(), exists);
+        if (alias != null) return alias;
+        return parsed;
+    }
+
+    private static ResourceLocation resolveAlias(String value, Predicate<ResourceLocation> exists) {
+        if (value == null || value.indexOf('_') < 0) return null;
+        List<ResourceLocation> candidates = new ArrayList<>();
+        for (int i = value.indexOf('_'); i >= 0; i = value.indexOf('_', i + 1)) {
+            if (i <= 0 || i >= value.length() - 1) continue;
+            ResourceLocation candidate = tryParseId(value.substring(0, i) + ":" + value.substring(i + 1));
+            if (candidate != null && exists.test(candidate)) candidates.add(candidate);
+        }
+        if (candidates.isEmpty()) return null;
+        candidates.sort(Comparator.comparingInt(id -> -id.getNamespace().length()));
+        return candidates.get(0);
+    }
+
+    private static ResourceLocation tryParseId(String value) {
+        try {
+            return ResourceLocation.parse(value);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static int path(CommandSourceStack source) {
+        success(source, "手动可吃配置文件：" + ManualFoodConfig.path().toAbsolutePath());
+        return 1;
+    }
+
+    private static int reload(CommandSourceStack source) {
+        ManualFoodConfig.load();
+        int synced = syncAllManualEntries(source);
+        success(source, "已重新读取手动可吃配置：" + ManualFoodConfig.path().toAbsolutePath() + "，已同步 " + synced + " 个已加载世界条目到原世界附件");
+        return 1;
+    }
+
+    private static int save(CommandSourceStack source) {
+        ManualFoodConfig.save();
+        success(source, "已保存手动可吃配置：" + ManualFoodConfig.path().toAbsolutePath());
+        return 1;
+    }
+
+    private static int add(CommandSourceStack source, ResourceLocation dimension, ResourceLocation itemId, int nutrition, float saturation, float eatSeconds, Boolean canAlwaysEat, String convertRaw, Integer bites, String bitesTypeRaw, Integer bitesOffset) {
+        if (!ManualFoodConfig.isValidItem(itemId)) return fail(source, "未知物品：" + itemId);
+        ManualFoodConfig.Entry entry = new ManualFoodConfig.Entry();
+        entry.enabled = true;
+        entry.nutrition = nutrition;
+        entry.saturation = saturation;
+        entry.eatSeconds = eatSeconds;
+        entry.canAlwaysEat = canAlwaysEat;
+        if (convertRaw != null && !convertRaw.isBlank() && !isClearToken(convertRaw)) {
+            ResourceLocation convert = resolveId(convertRaw, ManualFoodConfig::isValidItem);
+            if (!ManualFoodConfig.isValidItem(convert)) return fail(source, "未知转换物品：" + convertRaw + "（解析为 " + convert + "）");
+            entry.usingConvertsTo = convert.toString();
+        }
+        entry.bites = bites;
+        entry.bitesOffset = bitesOffset;
+        if (bitesTypeRaw != null) {
+            Integer type = parseBitesType(bitesTypeRaw);
+            if (type == null) return fail(source, "bitesType 只能是 bites/0 或 servings/1");
+            entry.bitesType = type;
+        }
+        put(dimension, itemId, entry);
+        resyncManualItem(source, dimension, itemId);
+        success(source, "已添加手动可吃物品：" + scopeName(dimension) + " " + ManualFoodConfig.describeEntry(itemId, entry));
+        return 1;
+    }
+
+    private static void put(ResourceLocation dimension, ResourceLocation itemId, ManualFoodConfig.Entry entry) {
+        if (dimension == null) ManualFoodConfig.putGlobal(itemId, entry);
+        else ManualFoodConfig.putWorld(dimension, itemId, entry);
+    }
+
+    private static int remove(CommandSourceStack source, ResourceLocation dimension, ResourceLocation itemId) {
+        boolean removed = dimension == null ? ManualFoodConfig.removeGlobal(itemId) : ManualFoodConfig.removeWorld(dimension, itemId);
+        if (!removed) return fail(source, "没有找到手动条目：" + scopeName(dimension) + " " + itemId);
+        resyncManualItem(source, dimension, itemId);
+        success(source, "已删除手动条目：" + scopeName(dimension) + " " + itemId);
+        return 1;
+    }
+
+    private static int setEntry(CommandSourceStack source, boolean global, ResourceLocation itemId, Consumer<ManualFoodConfig.Entry> updater, String field) {
+        if (!ManualFoodConfig.isValidItem(itemId)) return fail(source, "未知物品：" + itemId);
+        ResourceLocation dimension = global ? null : source.getLevel().dimension().location();
+        ManualFoodConfig.Entry entry = ManualFoodConfig.getOrCreate(dimension, itemId);
+        updater.accept(entry);
+        entry.sanitized();
+        ManualFoodConfig.save();
+        resyncManualItem(source, dimension, itemId);
+        success(source, "已修改 " + scopeName(dimension) + " " + itemId + " 的 " + field);
+        return 1;
+    }
+
+    private static int setConvert(CommandSourceStack source, boolean global, ResourceLocation itemId, String raw) {
+        if (!ManualFoodConfig.isValidItem(itemId)) return fail(source, "未知物品：" + itemId);
+        ResourceLocation dimension = global ? null : source.getLevel().dimension().location();
+        ManualFoodConfig.Entry entry = ManualFoodConfig.getOrCreate(dimension, itemId);
+        if (isClearToken(raw)) {
+            entry.usingConvertsTo = null;
+        } else {
+            ResourceLocation convert = resolveId(raw, ManualFoodConfig::isValidItem);
+            if (!ManualFoodConfig.isValidItem(convert)) return fail(source, "未知转换物品：" + raw + "（解析为 " + convert + "）");
+            entry.usingConvertsTo = convert.toString();
+        }
+        ManualFoodConfig.save();
+        resyncManualItem(source, dimension, itemId);
+        success(source, "已修改 " + scopeName(dimension) + " " + itemId + " 的 usingConvertsTo");
+        return 1;
+    }
+
+    private static int setBitesType(CommandSourceStack source, boolean global, ResourceLocation itemId, String raw) {
+        Integer type = parseBitesType(raw);
+        if (type == null) return fail(source, "bitesType 只能是 bites/0 或 servings/1");
+        return setEntry(source, global, itemId, e -> e.bitesType = type, "bitesType");
+    }
+
+
+    private static boolean isClearToken(String raw) {
+        if (raw == null) return false;
+        String value = raw.trim().toLowerCase(Locale.ROOT);
+        return value.equals("clear") || value.equals("none") || value.equals("-")
+                || value.equals("minecraft:clear") || value.equals("minecraft:none") || value.equals("minecraft:-");
+    }
+
+    private static Integer parseBitesType(String raw) {
+        String lower = raw.toLowerCase(Locale.ROOT);
+        if (lower.equals("bites") || lower.equals("bite") || lower.equals("0")) return 0;
+        if (lower.equals("servings") || lower.equals("serving") || lower.equals("1")) return 1;
+        return null;
+    }
+
+    private static int addEffect(CommandSourceStack source, boolean global, ResourceLocation itemId, ResourceLocation effectId, int duration, int amplifier, float probability) {
+        if (!ManualFoodConfig.isValidItem(itemId)) return fail(source, "未知物品：" + itemId);
+        if (!ManualFoodConfig.isValidEffect(effectId)) return fail(source, "未知效果：" + effectId);
+        ResourceLocation dimension = global ? null : source.getLevel().dimension().location();
+        ManualFoodConfig.Entry entry = ManualFoodConfig.getOrCreate(dimension, itemId);
+        ManualFoodConfig.EffectEntry effect = new ManualFoodConfig.EffectEntry();
+        effect.effect = effectId.toString();
+        effect.duration = duration;
+        effect.amplifier = amplifier;
+        effect.probability = probability;
+        entry.effects.add(effect.sanitized());
+        ManualFoodConfig.save();
+        resyncManualItem(source, dimension, itemId);
+        success(source, "已添加效果：" + scopeName(dimension) + " " + itemId + " -> " + effectId + " " + duration + "t amp=" + amplifier + " p=" + probability);
+        return 1;
+    }
+
+    private static int removeEffect(CommandSourceStack source, ResourceLocation dimension, ResourceLocation itemId, ResourceLocation effectId) {
+        Optional<ManualFoodConfig.Entry> opt = dimension == null
+                ? Optional.ofNullable(ManualFoodConfig.globalItems().get(itemId.toString()))
+                : Optional.ofNullable(ManualFoodConfig.worldItems(dimension).get(itemId.toString()));
+        if (opt.isEmpty()) return fail(source, "没有找到手动条目：" + scopeName(dimension) + " " + itemId);
+        ManualFoodConfig.Entry entry = ManualFoodConfig.getOrCreate(dimension, itemId);
+        int before = entry.effects.size();
+        entry.effects.removeIf(e -> effectId.toString().equals(e.effect));
+        ManualFoodConfig.save();
+        resyncManualItem(source, dimension, itemId);
+        success(source, "已删除 " + (before - entry.effects.size()) + " 个效果：" + scopeName(dimension) + " " + itemId + " -> " + effectId);
+        return 1;
+    }
+
+    private static int clearEffects(CommandSourceStack source, ResourceLocation dimension, ResourceLocation itemId) {
+        ManualFoodConfig.Entry entry = ManualFoodConfig.getOrCreate(dimension, itemId);
+        int before = entry.effects.size();
+        entry.effects.clear();
+        ManualFoodConfig.save();
+        resyncManualItem(source, dimension, itemId);
+        success(source, "已清空 " + scopeName(dimension) + " " + itemId + " 的效果，共 " + before + " 个");
+        return 1;
+    }
+
+    private static int listCurrent(CommandSourceStack source, int page) {
+        ServerLevel level = source.getLevel();
+        List<String> lines = new ArrayList<>(collectLevel(level, true).values());
+        return sendPage(source, "当前世界 " + level.dimension().location() + " 可吃名单", lines, page);
+    }
+
+    private static int listGlobal(CommandSourceStack source, int page) {
+        List<String> lines = ManualFoodConfig.globalItems().entrySet().stream()
+                .map(e -> "[manual/global] " + ManualFoodConfig.describeEntry(ResourceLocation.parse(e.getKey()), e.getValue()))
+                .toList();
+        return sendPage(source, "全局手动可吃名单", lines, page);
+    }
+
+    private static int listAll(CommandSourceStack source, int page) {
+        List<String> lines = new ArrayList<>();
+        ManualFoodConfig.globalItems().forEach((id, entry) -> lines.add("[manual/global] " + ManualFoodConfig.describeEntry(ResourceLocation.parse(id), entry)));
+        for (ServerLevel level : source.getServer().getAllLevels()) {
+            collectLevel(level, false).values().forEach(line -> lines.add("[" + level.dimension().location() + "] " + line));
+        }
+        return sendPage(source, "所有已加载世界可吃名单（手动/自动，省略重复的原版食物）", lines, page);
+    }
+
+    private static SortedMap<String, String> collectLevel(ServerLevel level, boolean includeVanilla) {
+        SortedMap<String, String> lines = new TreeMap<>();
+        ResourceLocation dimension = level.dimension().location();
+        ManualFoodConfig.globalItems().forEach((id, entry) -> lines.put(id + "#global", "[manual/global] " + ManualFoodConfig.describeEntry(ResourceLocation.parse(id), entry)));
+        ManualFoodConfig.worldItems(dimension).forEach((id, entry) -> lines.put(id + "#world", "[manual/world] " + ManualFoodConfig.describeEntry(ResourceLocation.parse(id), entry)));
+
+        LevelOrgFoodValue data = level.getData(ModAttachments.LEVEL_ORG_FOOD_VALUE);
+        for (ResourceLocation id : BuiltInRegistries.ITEM.keySet()) {
+            Item item = BuiltInRegistries.ITEM.get(id);
+            FoodProperties defaultFood = item.getDefaultInstance().get(DataComponents.FOOD);
+            if (LevelOrgFoodValue.isTrusted(data, item, null)) {
+                lines.putIfAbsent(id + "#auto", "[auto/world] " + describeAuto(id, item, data));
+            } else if (includeVanilla && defaultFood != null) {
+                lines.putIfAbsent(id + "#vanilla", "[vanilla] " + describeFood(id, defaultFood));
+            }
+        }
+        return lines;
+    }
+
+    private static String describeAuto(ResourceLocation id, Item item, LevelOrgFoodValue data) {
+        int defHash = LevelOrgFoodValue.getFoodHash(item, null);
+        StringBuilder sb = new StringBuilder(id.toString());
+        if (data.bites.containsKey(defHash)) sb.append(" bites=").append(data.bites.get(defHash));
+        if (data.bitesType.containsKey(defHash)) sb.append(" type=").append(data.bitesType.get(defHash) == 1 ? "servings" : "bites");
+        if (data.bitesOffset.containsKey(defHash)) sb.append(" offset=").append(data.bitesOffset.get(defHash));
+        int hash0 = LevelOrgFoodValue.getFoodHash(item, data.bitesType.getOrDefault(defHash, 0) == 1 ? data.bites.getOrDefault(defHash, 0) : 0);
+        if (data.hunger.containsKey(hash0)) sb.append(" hunger=").append(data.hunger.get(hash0));
+        if (data.saturation.containsKey(hash0)) sb.append(" saturation=").append(data.saturation.get(hash0));
+        if (data.usingConvertsTo.containsKey(hash0)) sb.append(" convert=").append(data.usingConvertsTo.get(hash0));
+        return sb.toString();
+    }
+
+    private static String describeFood(ResourceLocation id, FoodProperties food) {
+        StringBuilder sb = new StringBuilder(id.toString());
+        sb.append(" hunger=").append(food.nutrition());
+        sb.append(" saturation=").append(food.saturation());
+        sb.append(" eatSeconds=").append(food.eatSeconds());
+        if (food.canAlwaysEat()) sb.append(" alwaysEat=true");
+        food.usingConvertsTo().ifPresent(stack -> sb.append(" convert=").append(BuiltInRegistries.ITEM.getKey(stack.getItem())));
+        if (!food.effects().isEmpty()) sb.append(" effects=").append(food.effects().size());
+        return sb.toString();
+    }
+
+    private static int show(CommandSourceStack source, ServerLevel level, ResourceLocation itemId) {
+        Optional<Item> item = ManualFoodConfig.item(itemId);
+        if (item.isEmpty()) return fail(source, "未知物品：" + itemId);
+        List<String> lines = new ArrayList<>();
+        FoodProperties fallback = item.get().getDefaultInstance().get(DataComponents.FOOD);
+        lines.add("物品：" + itemId + " / 世界：" + level.dimension().location());
+        lines.add("原版FOOD：" + (fallback == null ? "无" : describeFood(itemId, fallback)));
+        ManualFoodConfig.getEntry(level, itemId).ifPresentOrElse(
+                entry -> lines.add("手动配置：" + describeManualEffective(itemId, item.get(), entry) + describeEffects(entry)),
+                () -> lines.add("手动配置：无")
+        );
+        LevelOrgFoodValue data = level.getData(ModAttachments.LEVEL_ORG_FOOD_VALUE);
+        lines.add("自动学习：" + (LevelOrgFoodValue.isTrusted(data, item.get(), null) ? describeAuto(itemId, item.get(), data) : "无/未信任"));
+        lines.forEach(line -> success(source, line));
+        return 1;
+    }
+
+    private static int showGlobal(CommandSourceStack source, ResourceLocation itemId) {
+        Optional<Item> item = ManualFoodConfig.item(itemId);
+        if (item.isEmpty()) return fail(source, "未知物品：" + itemId);
+        Optional<ManualFoodConfig.Entry> entry = Optional.ofNullable(ManualFoodConfig.globalItems().get(itemId.toString()));
+        entry.ifPresentOrElse(
+                value -> success(source, "全局手动配置：" + describeManualEffective(itemId, item.get(), value) + describeEffects(value)),
+                () -> fail(source, "没有全局手动配置：" + itemId)
+        );
+        return entry.isPresent() ? 1 : 0;
+    }
+
+    private static int showAll(CommandSourceStack source, ResourceLocation itemId) {
+        int shown = showGlobal(source, itemId);
+        for (ServerLevel level : source.getServer().getAllLevels()) shown += show(source, level, itemId);
+        return shown;
+    }
+
+    private static String describeManualEffective(ResourceLocation itemId, Item item, ManualFoodConfig.Entry entry) {
+        FoodProperties fallback = item.getDefaultInstance().get(DataComponents.FOOD);
+        Optional<FoodProperties> food = entry.toFoodProperties(fallback);
+        StringBuilder sb = new StringBuilder();
+        food.ifPresentOrElse(
+                value -> sb.append(describeFood(itemId, value)),
+                () -> sb.append(itemId).append(" effective=none")
+        );
+        if (entry.bites != null) sb.append(" bites=").append(entry.bites);
+        if (entry.bitesType != null) sb.append(" type=").append(entry.bitesType == 1 ? "servings" : "bites");
+        if (entry.bitesOffset != null) sb.append(" offset=").append(entry.bitesOffset);
+        return sb.toString();
+    }
+
+    private static String describeEffects(ManualFoodConfig.Entry entry) {
+        if (entry.effects == null || entry.effects.isEmpty()) return "";
+        StringBuilder sb = new StringBuilder(" effects=[");
+        for (int i = 0; i < entry.effects.size(); i++) {
+            ManualFoodConfig.EffectEntry e = entry.effects.get(i);
+            if (i > 0) sb.append(", ");
+            sb.append(e.effect).append(" ").append(e.duration).append("t amp=").append(e.amplifier).append(" p=").append(e.probability);
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private static int syncAllManualEntries(CommandSourceStack source) {
+        int synced = 0;
+        for (ServerLevel level : source.getServer().getAllLevels()) {
+            Set<ResourceLocation> ids = new TreeSet<>();
+            ManualFoodConfig.globalItems().keySet().forEach(id -> ids.add(ResourceLocation.parse(id)));
+            ManualFoodConfig.worldItems(level.dimension().location()).keySet().forEach(id -> ids.add(ResourceLocation.parse(id)));
+            for (ResourceLocation id : ids) {
+                resyncManualItemToLevel(level, id);
+                synced++;
+            }
+        }
+        return synced;
+    }
+
+    private static void resyncManualItem(CommandSourceStack source, ResourceLocation dimension, ResourceLocation itemId) {
+        for (ServerLevel level : source.getServer().getAllLevels()) {
+            if (dimension != null && !level.dimension().location().equals(dimension)) continue;
+            resyncManualItemToLevel(level, itemId);
+        }
+    }
+
+    private static void resyncManualItemToLevel(ServerLevel level, ResourceLocation itemId) {
+        Optional<Item> item = ManualFoodConfig.item(itemId);
+        if (item.isEmpty()) return;
+        Optional<ManualFoodConfig.Entry> entry = ManualFoodConfig.getEntry(level, itemId);
+        if (entry.isPresent()) syncManualEntryToAttachment(level, itemId, item.get(), entry.get());
+        else clearItemFromAttachment(level, item.get());
+    }
+
+    private static void syncManualEntryToAttachment(ServerLevel level, ResourceLocation itemId, Item item, ManualFoodConfig.Entry entry) {
+        LevelOrgFoodValue data = level.getData(ModAttachments.LEVEL_ORG_FOOD_VALUE);
+        FoodProperties fallback = item.getDefaultInstance().get(DataComponents.FOOD);
+        int nutrition = entry.nutrition != null ? entry.nutrition : fallback != null ? fallback.nutrition() : 0;
+        float saturation = entry.saturation != null ? entry.saturation : fallback != null ? fallback.saturation() : 0F;
+        int finalBites = Math.max(1, entry.bites == null ? 1 : entry.bites);
+        int type = entry.bitesType == null ? 0 : entry.bitesType;
+        int offset = Math.max(0, entry.bitesOffset == null ? 0 : entry.bitesOffset);
+        float perBiteHunger = nutrition / (float) finalBites;
+        float perBiteSaturation = saturation / (float) finalBites;
+
+        int defHash = LevelOrgFoodValue.getFoodHash(item, null);
+        data.hash.add(defHash);
+        LevelOrgFoodValue.markTrusted(data, item, null);
+        if (entry.bites != null) data.bites.put(defHash, finalBites);
+        else data.bites.remove(defHash);
+        if (entry.bitesType != null) data.bitesType.put(defHash, type);
+        else data.bitesType.remove(defHash);
+        if (entry.bitesOffset != null) data.bitesOffset.put(defHash, offset);
+        else data.bitesOffset.remove(defHash);
+
+        int first = type == 1 ? 1 : 0;
+        int endExclusive = type == 1 ? finalBites + 1 : Math.max(1, finalBites + offset);
+        for (int bite = first; bite < endExclusive; bite++) {
+            int hash = LevelOrgFoodValue.getFoodHash(item, bite);
+            data.hash.add(hash);
+            LevelOrgFoodValue.markTrusted(data, item, bite);
+            data.hunger.put(hash, perBiteHunger);
+            data.saturation.put(hash, perBiteSaturation);
+            ResourceLocation convert = tryParseId(entry.usingConvertsTo == null ? "" : entry.usingConvertsTo);
+            if (convert != null && ManualFoodConfig.isValidItem(convert)) {
+                data.usingConvertsTo.put(hash, convert);
+            } else {
+                data.usingConvertsTo.remove(hash);
+            }
+        }
+
+        // Also keep the legacy display hash populated for non-sliced/manual foods.
+        int displayHash = LevelOrgFoodValue.getFoodHash(item, type == 1 ? finalBites : 0);
+        data.hash.add(displayHash);
+        LevelOrgFoodValue.markTrusted(data, item, type == 1 ? finalBites : 0);
+        data.hunger.put(displayHash, perBiteHunger);
+        data.saturation.put(displayHash, perBiteSaturation);
+        ResourceLocation displayConvert = tryParseId(entry.usingConvertsTo == null ? "" : entry.usingConvertsTo);
+        if (displayConvert != null && ManualFoodConfig.isValidItem(displayConvert)) {
+            data.usingConvertsTo.put(displayHash, displayConvert);
+        } else {
+            data.usingConvertsTo.remove(displayHash);
+        }
+
+        level.setData(ModAttachments.LEVEL_ORG_FOOD_VALUE, data);
+    }
+
+    private static void clearItemFromAttachment(ServerLevel level, Item item) {
+        LevelOrgFoodValue data = level.getData(ModAttachments.LEVEL_ORG_FOOD_VALUE);
+        int defHash = LevelOrgFoodValue.getFoodHash(item, null);
+        Integer bites = data.bites.get(defHash);
+        Integer type = data.bitesType.get(defHash);
+        Integer offset = data.bitesOffset.get(defHash);
+        Set<Integer> hashes = new HashSet<>();
+        hashes.add(defHash);
+        hashes.add(LevelOrgFoodValue.getFoodHash(item, 0));
+        if (bites != null) {
+            int first = Objects.equals(type, 1) ? 1 : 0;
+            int endExclusive = Objects.equals(type, 1) ? bites + 1 : Math.max(1, bites + Math.max(0, offset == null ? 0 : offset));
+            for (int bite = first; bite < endExclusive; bite++) hashes.add(LevelOrgFoodValue.getFoodHash(item, bite));
+        }
+        for (Integer hash : hashes) removeHash(data, hash);
+        level.setData(ModAttachments.LEVEL_ORG_FOOD_VALUE, data);
+    }
+
+    private static void removeHash(LevelOrgFoodValue data, int hash) {
+        data.hash.remove(hash);
+        data.hunger.remove(hash);
+        data.saturation.remove(hash);
+        data.bites.remove(hash);
+        data.bitesOffset.remove(hash);
+        data.bitesType.remove(hash);
+        data.usingConvertsTo.remove(hash);
+        data.itemIds.remove(hash);
+    }
+
+    private static int importLegacyCurrent(CommandSourceStack source) {
+        return importLegacy(source, List.of(source.getLevel()));
+    }
+
+    private static int importLegacyAll(CommandSourceStack source) {
+        List<ServerLevel> levels = new ArrayList<>();
+        source.getServer().getAllLevels().forEach(levels::add);
+        return importLegacy(source, levels);
+    }
+
+    private static int importLegacy(CommandSourceStack source, Collection<ServerLevel> levels) {
+        int imported = 0;
+        for (ServerLevel level : levels) {
+            LevelOrgFoodValue data = level.getData(ModAttachments.LEVEL_ORG_FOOD_VALUE);
+            for (ResourceLocation id : BuiltInRegistries.ITEM.keySet()) {
+                Item item = BuiltInRegistries.ITEM.get(id);
+                int legacyDef = LevelOrgFoodValue.getLegacyFoodHash(item, null);
+                int currentDef = LevelOrgFoodValue.getFoodHash(item, null);
+                if (!data.hash.contains(legacyDef) && !data.hash.contains(currentDef)) continue;
+                ManualFoodConfig.Entry entry = legacyEntryFrom(data, item, legacyDef, currentDef);
+                ManualFoodConfig.putWorld(level.dimension().location(), id, entry);
+                imported++;
+            }
+        }
+        ManualFoodConfig.save();
+        success(source, "已从旧隐藏世界附件导入 " + imported + " 个条目到 " + ManualFoodConfig.path().toAbsolutePath());
+        return imported;
+    }
+
+    private static ManualFoodConfig.Entry legacyEntryFrom(LevelOrgFoodValue data, Item item, int legacyDef, int currentDef) {
+        ManualFoodConfig.Entry entry = new ManualFoodConfig.Entry();
+        int defHash = data.hash.contains(legacyDef) ? legacyDef : currentDef;
+        entry.bites = data.bites.get(defHash);
+        entry.bitesOffset = data.bitesOffset.get(defHash);
+        entry.bitesType = data.bitesType.get(defHash);
+        int finalBites = entry.bites == null ? 1 : entry.bites;
+        int valueBite = entry.bitesType != null && entry.bitesType == 1 ? finalBites : 0;
+        int oldValueHash = LevelOrgFoodValue.getLegacyFoodHash(item, valueBite);
+        int newValueHash = LevelOrgFoodValue.getFoodHash(item, valueBite);
+        Float hunger = data.hunger.getOrDefault(oldValueHash, data.hunger.get(newValueHash));
+        Float saturation = data.saturation.getOrDefault(oldValueHash, data.saturation.get(newValueHash));
+        if (hunger != null) entry.nutrition = Math.round(hunger * Math.max(1, finalBites));
+        if (saturation != null) entry.saturation = saturation * Math.max(1, finalBites);
+        ResourceLocation convert = data.usingConvertsTo.getOrDefault(oldValueHash, data.usingConvertsTo.get(newValueHash));
+        if (convert != null) entry.usingConvertsTo = convert.toString();
+        FoodProperties fallback = item.getDefaultInstance().get(DataComponents.FOOD);
+        if (entry.nutrition == null && fallback != null) entry.nutrition = fallback.nutrition();
+        if (entry.saturation == null && fallback != null) entry.saturation = fallback.saturation();
+        return entry.sanitized();
+    }
+
+    private static int sendPage(CommandSourceStack source, String title, List<String> lines, int page) {
+        if (lines.isEmpty()) {
+            success(source, title + "：空");
+            return 0;
+        }
+        int maxPage = Math.max(1, (int) Math.ceil(lines.size() / (double) PAGE_SIZE));
+        int safePage = Math.max(1, Math.min(page, maxPage));
+        success(source, title + " 第 " + safePage + "/" + maxPage + " 页，共 " + lines.size() + " 条");
+        int from = (safePage - 1) * PAGE_SIZE;
+        int to = Math.min(lines.size(), from + PAGE_SIZE);
+        for (int i = from; i < to; i++) success(source, (i + 1) + ". " + lines.get(i));
+        return lines.size();
+    }
+
+    private static String scopeName(ResourceLocation dimension) {
+        return dimension == null ? "global" : dimension.toString();
+    }
+
+    private static void success(CommandSourceStack source, String message) {
+        source.sendSuccess(() -> Component.literal(message), false);
+    }
+
+    private static int fail(CommandSourceStack source, String message) {
+        source.sendFailure(Component.literal(message));
+        return 0;
+    }
+}

--- a/src/main/java/com/xdw/spiceoflifelatiao/config/ManualFoodConfig.java
+++ b/src/main/java/com/xdw/spiceoflifelatiao/config/ManualFoodConfig.java
@@ -1,0 +1,375 @@
+package com.xdw.spiceoflifelatiao.config;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.xdw.spiceoflifelatiao.SpiceOfLifeLatiao;
+import net.minecraft.core.Holder;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.food.FoodProperties;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.neoforged.fml.loading.FMLPaths;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+
+/**
+ * Human editable manual edible-item database.
+ *
+ * Location: <server root>/config/spiceoflifelatiao/edible_items.json
+ *
+ * The old Level attachment is still used for automatic discovery, but this file is the authoritative
+ * place for administrator-created edible items and survives world reloads / server restarts.
+ */
+public final class ManualFoodConfig {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+    private static final Path CONFIG_PATH = FMLPaths.CONFIGDIR.get()
+            .resolve(SpiceOfLifeLatiao.MODID)
+            .resolve("edible_items.json");
+
+    private static Store store = new Store();
+    private static boolean loaded = false;
+
+    private ManualFoodConfig() {}
+
+    public static Path path() {
+        return CONFIG_PATH;
+    }
+
+    public static synchronized void load() {
+        try {
+            Files.createDirectories(CONFIG_PATH.getParent());
+            if (!Files.exists(CONFIG_PATH)) {
+                store = Store.defaults();
+                save();
+                loaded = true;
+                return;
+            }
+            try (Reader reader = Files.newBufferedReader(CONFIG_PATH, StandardCharsets.UTF_8)) {
+                Store parsed = GSON.fromJson(reader, Store.class);
+                store = parsed == null ? Store.defaults() : parsed.sanitized();
+            }
+            loaded = true;
+        } catch (IOException | JsonSyntaxException e) {
+            SpiceOfLifeLatiao.LOGGER.error("Failed to load manual food config from {}", CONFIG_PATH, e);
+            store = Store.defaults();
+            loaded = true;
+        }
+    }
+
+    public static synchronized void save() {
+        try {
+            Files.createDirectories(CONFIG_PATH.getParent());
+            try (Writer writer = Files.newBufferedWriter(CONFIG_PATH, StandardCharsets.UTF_8)) {
+                GSON.toJson(store.sanitized(), writer);
+            }
+        } catch (IOException e) {
+            SpiceOfLifeLatiao.LOGGER.error("Failed to save manual food config to {}", CONFIG_PATH, e);
+        }
+    }
+
+    private static synchronized Store getStore() {
+        if (!loaded) load();
+        return store;
+    }
+
+    public static synchronized Map<String, Entry> globalItems() {
+        return Collections.unmodifiableMap(new TreeMap<>(getStore().global));
+    }
+
+    public static synchronized Map<String, Entry> worldItems(ResourceLocation dimension) {
+        return Collections.unmodifiableMap(new TreeMap<>(getStore().worlds.getOrDefault(dimension.toString(), new TreeMap<>())));
+    }
+
+    public static synchronized Map<String, Map<String, Entry>> allWorldItems() {
+        Map<String, Map<String, Entry>> out = new TreeMap<>();
+        getStore().worlds.forEach((world, items) -> out.put(world, Collections.unmodifiableMap(new TreeMap<>(items))));
+        return Collections.unmodifiableMap(out);
+    }
+
+
+    /**
+     * True when an item has any enabled manual entry, including dimension-scoped entries.
+     * Useful for client-only places where no Level is available, such as use animation.
+     */
+    public static synchronized boolean hasAnyEnabledEntry(Item item) {
+        ResourceLocation itemId = BuiltInRegistries.ITEM.getKey(item);
+        if (itemId == null) return false;
+        String key = itemId.toString();
+        Store s = getStore();
+        Entry globalEntry = s.global.get(key);
+        if (globalEntry != null && globalEntry.enabled) return true;
+        return s.worlds.values().stream().anyMatch(items -> {
+            Entry entry = items.get(key);
+            return entry != null && entry.enabled;
+        });
+    }
+
+    /**
+     * Default item components are global, not dimension-scoped. Global entries are preferred.
+     * World entries are accepted as a compatibility fallback for entries created with
+     * /sol_latiao food add current, but only when the item has no global entry.
+     */
+    public static synchronized Map<String, Entry> startupComponentEntries() {
+        TreeMap<String, Entry> out = new TreeMap<>();
+        getStore().global.forEach((id, entry) -> {
+            if (entry != null && entry.enabled) out.put(id, entry.copy().sanitized());
+        });
+        getStore().worlds.forEach((dimension, items) -> {
+            if (items == null) return;
+            items.forEach((id, entry) -> {
+                if (entry != null && entry.enabled) out.putIfAbsent(id, entry.copy().sanitized());
+            });
+        });
+        return Collections.unmodifiableMap(out);
+    }
+
+    public static synchronized Optional<Entry> getEntry(@Nullable Level level, Item item) {
+        ResourceLocation itemId = BuiltInRegistries.ITEM.getKey(item);
+        if (itemId == null) return Optional.empty();
+        return getEntry(level, itemId);
+    }
+
+    public static synchronized Optional<Entry> getEntry(@Nullable Level level, ResourceLocation itemId) {
+        Store s = getStore();
+        if (level != null) {
+            Map<String, Entry> world = s.worlds.get(level.dimension().location().toString());
+            if (world != null) {
+                Entry entry = world.get(itemId.toString());
+                if (entry != null && entry.enabled) return Optional.of(entry.copy());
+            }
+        }
+        Entry entry = s.global.get(itemId.toString());
+        return entry != null && entry.enabled ? Optional.of(entry.copy()) : Optional.empty();
+    }
+
+    public static Optional<FoodProperties> getFoodProperties(@Nullable Level level, ItemStack stack, @Nullable FoodProperties fallback) {
+        return getEntry(level, stack.getItem()).flatMap(entry -> entry.toFoodProperties(fallback));
+    }
+
+    public static synchronized void putGlobal(ResourceLocation itemId, Entry entry) {
+        Store s = getStore();
+        s.global.put(itemId.toString(), entry.sanitized());
+        save();
+    }
+
+    public static synchronized void putWorld(ResourceLocation dimension, ResourceLocation itemId, Entry entry) {
+        Store s = getStore();
+        s.worlds.computeIfAbsent(dimension.toString(), ignored -> new TreeMap<>()).put(itemId.toString(), entry.sanitized());
+        save();
+    }
+
+    public static synchronized boolean removeGlobal(ResourceLocation itemId) {
+        boolean removed = getStore().global.remove(itemId.toString()) != null;
+        if (removed) save();
+        return removed;
+    }
+
+    public static synchronized boolean removeWorld(ResourceLocation dimension, ResourceLocation itemId) {
+        Map<String, Entry> world = getStore().worlds.get(dimension.toString());
+        if (world == null) return false;
+        boolean removed = world.remove(itemId.toString()) != null;
+        if (world.isEmpty()) getStore().worlds.remove(dimension.toString());
+        if (removed) save();
+        return removed;
+    }
+
+    public static synchronized Entry getOrCreate(@Nullable ResourceLocation dimension, ResourceLocation itemId) {
+        Store s = getStore();
+        Entry entry;
+        if (dimension == null) {
+            entry = s.global.computeIfAbsent(itemId.toString(), ignored -> new Entry());
+        } else {
+            entry = s.worlds.computeIfAbsent(dimension.toString(), ignored -> new TreeMap<>())
+                    .computeIfAbsent(itemId.toString(), ignored -> new Entry());
+        }
+        entry.enabled = true;
+        return entry;
+    }
+
+    public static boolean isValidItem(ResourceLocation itemId) {
+        return BuiltInRegistries.ITEM.containsKey(itemId);
+    }
+
+    public static boolean isValidEffect(ResourceLocation effectId) {
+        return BuiltInRegistries.MOB_EFFECT.containsKey(effectId);
+    }
+
+    public static Optional<Item> item(ResourceLocation id) {
+        if (!BuiltInRegistries.ITEM.containsKey(id)) return Optional.empty();
+        return Optional.of(BuiltInRegistries.ITEM.get(id));
+    }
+
+    public static String describeEntry(ResourceLocation itemId, Entry entry) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(itemId).append(" hunger=").append(entry.nutrition == null ? "default" : entry.nutrition);
+        sb.append(" saturation=").append(entry.saturation == null ? "default" : entry.saturation);
+        sb.append(" eatSeconds=").append(entry.eatSeconds == null ? "default" : entry.eatSeconds);
+        sb.append(" alwaysEat=").append(entry.canAlwaysEat == null ? "default" : entry.canAlwaysEat);
+        if (entry.usingConvertsTo != null && !entry.usingConvertsTo.isBlank()) sb.append(" convert=").append(entry.usingConvertsTo);
+        if (entry.bites != null) sb.append(" bites=").append(entry.bites);
+        if (entry.bitesType != null) sb.append(" type=").append(entry.bitesType == 1 ? "servings" : "bites");
+        if (entry.bitesOffset != null) sb.append(" offset=").append(entry.bitesOffset);
+        if (entry.effects != null && !entry.effects.isEmpty()) sb.append(" effects=").append(entry.effects.size());
+        return sb.toString();
+    }
+
+    public static final class Store {
+        public int format = 1;
+        public String comment = "Manual edible items. Global entries apply to every loaded world; worlds entries override global per dimension.";
+        public Map<String, Entry> global = new TreeMap<>();
+        public Map<String, Map<String, Entry>> worlds = new TreeMap<>();
+
+        public static Store defaults() {
+            return new Store().sanitized();
+        }
+
+        public Store sanitized() {
+            if (format <= 0) format = 1;
+            if (global == null) global = new TreeMap<>();
+            if (worlds == null) worlds = new TreeMap<>();
+            global.replaceAll((k, v) -> v == null ? new Entry() : v.sanitized());
+            worlds.replaceAll((world, items) -> {
+                Map<String, Entry> out = new TreeMap<>();
+                if (items != null) items.forEach((item, entry) -> out.put(item, entry == null ? new Entry() : entry.sanitized()));
+                return out;
+            });
+            return this;
+        }
+    }
+
+    public static final class Entry {
+        public boolean enabled = true;
+        public Integer nutrition = null;
+        public Float saturation = null;
+        public Float eatSeconds = null;
+        public Boolean canAlwaysEat = null;
+        public String usingConvertsTo = null;
+        public Integer bites = null;
+        /** 0 = bites decreasing from 0, 1 = servings accumulating from 1. */
+        public Integer bitesType = null;
+        public Integer bitesOffset = null;
+        public List<EffectEntry> effects = new ArrayList<>();
+
+        public Entry sanitized() {
+            if (saturation != null && (!Float.isFinite(saturation) || saturation < 0)) saturation = 0F;
+            if (eatSeconds != null && (!Float.isFinite(eatSeconds) || eatSeconds <= 0)) eatSeconds = 1.6F;
+            if (nutrition != null && nutrition < 0) nutrition = 0;
+            if (bites != null && bites < 1) bites = 1;
+            if (bitesType != null && bitesType != 0 && bitesType != 1) bitesType = 0;
+            if (bitesOffset != null && bitesOffset < 0) bitesOffset = 0;
+            if (effects == null) effects = new ArrayList<>();
+            effects.replaceAll(e -> e == null ? new EffectEntry() : e.sanitized());
+            return this;
+        }
+
+        public Entry copy() {
+            Entry copy = new Entry();
+            copy.enabled = enabled;
+            copy.nutrition = nutrition;
+            copy.saturation = saturation;
+            copy.eatSeconds = eatSeconds;
+            copy.canAlwaysEat = canAlwaysEat;
+            copy.usingConvertsTo = usingConvertsTo;
+            copy.bites = bites;
+            copy.bitesType = bitesType;
+            copy.bitesOffset = bitesOffset;
+            copy.effects = new ArrayList<>();
+            if (effects != null) effects.forEach(e -> copy.effects.add(e.copy()));
+            return copy;
+        }
+
+        public Optional<FoodProperties> toFoodProperties(@Nullable FoodProperties fallback) {
+            int finalNutrition = nutrition != null ? nutrition : fallback != null ? fallback.nutrition() : 0;
+            float finalSaturation = saturation != null ? saturation : fallback != null ? fallback.saturation() : 0F;
+            float finalEatSeconds = eatSeconds != null ? eatSeconds : fallback != null ? fallback.eatSeconds() : 1.6F;
+            boolean finalCanAlwaysEat = canAlwaysEat != null ? canAlwaysEat : fallback != null && fallback.canAlwaysEat();
+            Optional<ItemStack> finalConvert = parseConvert().or(() -> fallback == null ? Optional.empty() : fallback.usingConvertsTo());
+            List<FoodProperties.PossibleEffect> finalEffects = buildEffects();
+            if (finalEffects.isEmpty() && fallback != null) finalEffects = fallback.effects();
+            if (finalNutrition == 0 && finalSaturation == 0F && finalConvert.isEmpty() && finalEffects.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(new FoodProperties(finalNutrition, finalSaturation, finalCanAlwaysEat, finalEatSeconds, finalConvert, finalEffects));
+        }
+
+        private Optional<ItemStack> parseConvert() {
+            if (usingConvertsTo == null || usingConvertsTo.isBlank()) return Optional.empty();
+            try {
+                ResourceLocation id = ResourceLocation.parse(usingConvertsTo);
+                if (!BuiltInRegistries.ITEM.containsKey(id)) return Optional.empty();
+                return Optional.of(BuiltInRegistries.ITEM.get(id).getDefaultInstance());
+            } catch (Exception ignored) {
+                return Optional.empty();
+            }
+        }
+
+        private List<FoodProperties.PossibleEffect> buildEffects() {
+            if (effects == null || effects.isEmpty()) return List.of();
+            List<FoodProperties.PossibleEffect> out = new ArrayList<>();
+            for (EffectEntry effect : effects) {
+                effect.toPossibleEffect().ifPresent(out::add);
+            }
+            return out;
+        }
+    }
+
+    public static final class EffectEntry {
+        public String effect = "minecraft:speed";
+        public int duration = 200;
+        public int amplifier = 0;
+        public float probability = 1.0F;
+        public boolean ambient = false;
+        public boolean visible = true;
+        public boolean showIcon = true;
+
+        public EffectEntry sanitized() {
+            if (duration < 1) duration = 1;
+            if (amplifier < 0) amplifier = 0;
+            if (!Float.isFinite(probability)) probability = 1F;
+            probability = Math.max(0F, Math.min(1F, probability));
+            if (effect == null || effect.isBlank()) effect = "minecraft:speed";
+            return this;
+        }
+
+        public EffectEntry copy() {
+            EffectEntry copy = new EffectEntry();
+            copy.effect = effect;
+            copy.duration = duration;
+            copy.amplifier = amplifier;
+            copy.probability = probability;
+            copy.ambient = ambient;
+            copy.visible = visible;
+            copy.showIcon = showIcon;
+            return copy;
+        }
+
+        public Optional<FoodProperties.PossibleEffect> toPossibleEffect() {
+            try {
+                ResourceLocation id = ResourceLocation.parse(effect);
+                ResourceKey<MobEffect> key = ResourceKey.create(Registries.MOB_EFFECT, id);
+                Optional<Holder.Reference<MobEffect>> holder = BuiltInRegistries.MOB_EFFECT.getHolder(key);
+                return holder.map(mobEffectReference -> new FoodProperties.PossibleEffect(
+                        () -> new MobEffectInstance(mobEffectReference, duration, amplifier, ambient, visible, showIcon),
+                        probability
+                ));
+            } catch (Exception ignored) {
+                return Optional.empty();
+            }
+        }
+    }
+}

--- a/src/main/java/com/xdw/spiceoflifelatiao/event/ManualFoodComponentEvent.java
+++ b/src/main/java/com/xdw/spiceoflifelatiao/event/ManualFoodComponentEvent.java
@@ -1,0 +1,69 @@
+package com.xdw.spiceoflifelatiao.event;
+
+import com.xdw.spiceoflifelatiao.SpiceOfLifeLatiao;
+import com.xdw.spiceoflifelatiao.cached.ConfigCached;
+import com.xdw.spiceoflifelatiao.config.ManualFoodConfig;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.food.FoodProperties;
+import net.minecraft.world.item.Item;
+import net.neoforged.neoforge.event.ModifyDefaultComponentsEvent;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Applies config/spiceoflifelatiao/edible_items.json to the real default item components.
+ *
+ * The older logic in LevelOrgFoodValue/IItemExtensionMixin can still calculate dynamic/world-specific
+ * values, but tools such as Jade, AppleSkin and vanilla interaction code commonly check the FOOD data
+ * component directly.  Setting DataComponents.FOOD here makes manually configured items standard food
+ * after a restart, which is deterministic and does not require a runtime sync packet.
+ */
+public final class ManualFoodComponentEvent {
+    private ManualFoodComponentEvent() {}
+
+    public static void modifyDefaultComponents(ModifyDefaultComponentsEvent event) {
+        if (!ConfigCached.ENABLE_MANUAL_FOOD_FILE) return;
+
+        // Ensure the file exists and is parsed before default components are frozen.
+        ManualFoodConfig.load();
+
+        int patched = 0;
+        for (Map.Entry<String, ManualFoodConfig.Entry> raw : ManualFoodConfig.startupComponentEntries().entrySet()) {
+            ResourceLocation itemId = tryParse(raw.getKey()).orElse(null);
+            if (itemId == null) {
+                SpiceOfLifeLatiao.LOGGER.warn("Skipping invalid manual food item id in {}: {}", ManualFoodConfig.path(), raw.getKey());
+                continue;
+            }
+            if (!BuiltInRegistries.ITEM.containsKey(itemId)) {
+                SpiceOfLifeLatiao.LOGGER.warn("Skipping unknown manual food item in {}: {}", ManualFoodConfig.path(), itemId);
+                continue;
+            }
+
+            Item item = BuiltInRegistries.ITEM.get(itemId);
+            FoodProperties fallback = item.getDefaultInstance().get(DataComponents.FOOD);
+            Optional<FoodProperties> food = raw.getValue().toFoodProperties(fallback);
+            if (food.isEmpty()) {
+                SpiceOfLifeLatiao.LOGGER.warn("Skipping manual food item with empty effective food values in {}: {}", ManualFoodConfig.path(), itemId);
+                continue;
+            }
+
+            event.modify(item, builder -> builder.set(DataComponents.FOOD, food.get()));
+            patched++;
+        }
+
+        if (patched > 0) {
+            SpiceOfLifeLatiao.LOGGER.info("Applied {} manual edible item(s) to default FOOD components from {}", patched, ManualFoodConfig.path());
+        }
+    }
+
+    private static Optional<ResourceLocation> tryParse(String id) {
+        try {
+            return Optional.of(ResourceLocation.parse(id));
+        } catch (Exception ignored) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/xdw/spiceoflifelatiao/linkage/jade/FoodInfoPlugin.java
+++ b/src/main/java/com/xdw/spiceoflifelatiao/linkage/jade/FoodInfoPlugin.java
@@ -3,6 +3,8 @@ package com.xdw.spiceoflifelatiao.linkage.jade;
 import com.xdw.spiceoflifelatiao.SpiceOfLifeLatiao;
 import com.xdw.spiceoflifelatiao.attachments.LevelOrgFoodValue;
 import com.xdw.spiceoflifelatiao.attachments.ModAttachments;
+import com.xdw.spiceoflifelatiao.cached.ConfigCached;
+import com.xdw.spiceoflifelatiao.config.ManualFoodConfig;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.component.DataComponents;
@@ -149,10 +151,11 @@ public class FoodInfoPlugin implements IWailaPlugin, IBlockComponentProvider {
         if (!player.isAddedToLevel() || player.tickCount <= 0)
             return false;
         if(stack.get(DataComponents.FOOD) != null) return true;
+        if(ConfigCached.ENABLE_MANUAL_FOOD_FILE && ManualFoodConfig.getEntry(player.level(), stack.getItem()).isPresent()) return true;
         LevelOrgFoodValue data = player.level().getData(ModAttachments.LEVEL_ORG_FOOD_VALUE);
         int defHash = LevelOrgFoodValue.getFoodHash(stack.getItem(), null);
-        boolean isBlockFood = Optional.ofNullable(data.bites.get(defHash)).isPresent();
-        if (!isBlockFood && !data.hash.contains(defHash) && stack.getItem() instanceof BlockItem bi) {
+        boolean isBlockFood = LevelOrgFoodValue.isTrusted(data, stack.getItem(), null) && Optional.ofNullable(data.bites.get(defHash)).isPresent();
+        if (ConfigCached.ENABLE_AUTO_BLOCK_FOOD_COLLECT && !isBlockFood && !LevelOrgFoodValue.isTrusted(data, stack.getItem(), null) && stack.getItem() instanceof BlockItem bi) {
             isBlockFood = state.getValues().keySet().stream().anyMatch(comparable -> comparable instanceof IntegerProperty ip && (ip.getName().equals("bites") || ip.getName().equals("servings")));
         }
         return isBlockFood;

--- a/src/main/java/com/xdw/spiceoflifelatiao/mixin/IItemExtensionMixin.java
+++ b/src/main/java/com/xdw/spiceoflifelatiao/mixin/IItemExtensionMixin.java
@@ -1,11 +1,11 @@
 package com.xdw.spiceoflifelatiao.mixin;
 
 import com.xdw.spiceoflifelatiao.attachments.LevelOrgFoodValue;
-import com.xdw.spiceoflifelatiao.attachments.ModAttachments;
 import com.xdw.spiceoflifelatiao.cached.ConfigCached;
 import com.xdw.spiceoflifelatiao.cached.FoodDataCached;
 import com.xdw.spiceoflifelatiao.cached.FoodPropertiesCached;
 import com.xdw.spiceoflifelatiao.cached.LevelCalcCached;
+import com.xdw.spiceoflifelatiao.config.ManualFoodConfig;
 import com.xdw.spiceoflifelatiao.linkage.IFoodItem;
 import com.xdw.spiceoflifelatiao.util.EatHistory;
 import net.minecraft.core.component.DataComponents;
@@ -19,7 +19,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -38,19 +37,30 @@ public interface IItemExtensionMixin {
         AtomicReference<FoodProperties> food = new AtomicReference<>();
         FoodPropertiesCached.getCached(entity, stack)
                 .or(() -> {
-                    AtomicReference<Optional<FoodProperties>> f = new AtomicReference<>(Optional.ofNullable(stack.getItem().getDefaultInstance().get(DataComponents.FOOD)));
+                    AtomicReference<Optional<FoodProperties>> f = new AtomicReference<>(Optional.ofNullable(stack.get(DataComponents.FOOD)));
                     if (EatHistory.recentEntity.isEmpty()) return f.get();
                     if (!(EatHistory.recentEntity.get() instanceof Player player)) return f.get();
 //                   其他来源，如饭盒
                     if (stack.getItem() instanceof IFoodItem box) {
                         f.set(box.getFoodProperties(stack, player));
                     }
+                    if (ConfigCached.ENABLE_MANUAL_FOOD_FILE) {
+                        // Manual entries are an override layer. If there is no manual entry for this item,
+                        // keep the item's original FOOD component (vanilla / other mods). Replacing it with
+                        // Optional.empty() makes every non-manual food non-edible.
+                        ManualFoodConfig.getFoodProperties(player.level(), stack, f.get().orElse(null))
+                                .ifPresent(value -> f.set(Optional.of(value)));
+                    }
                     f.get().ifPresent(it -> FoodPropertiesCached.addCached(player, stack, it));
                     return f.get();
                 })
                 .ifPresent(food::set);
+        if (ConfigCached.ENABLE_MANUAL_FOOD_FILE && entity instanceof Player player) {
+            ManualFoodConfig.getFoodProperties(player.level(), stack, food.get()).ifPresent(food::set);
+        }
         if (!ConfigCached.EANBLE_CHANGE) return food.get();
         if(EatHistory.recentEntity.isPresent() && !(EatHistory.recentEntity.get() instanceof Player)) return food.get();
+        if (food.get() == null && !ConfigCached.ENABLE_AUTO_BLOCK_FOOD_COLLECT) return null;
         AtomicInteger nutrition = new AtomicInteger(0);
         AtomicReference<Float> saturation = new AtomicReference<>(0F);
         AtomicReference<Float> eatSeconds = new AtomicReference<>(1.6F);

--- a/src/main/java/com/xdw/spiceoflifelatiao/mixin/ItemMixin.java
+++ b/src/main/java/com/xdw/spiceoflifelatiao/mixin/ItemMixin.java
@@ -1,10 +1,18 @@
 package com.xdw.spiceoflifelatiao.mixin;
 
+import com.xdw.spiceoflifelatiao.cached.ConfigCached;
 import com.xdw.spiceoflifelatiao.cached.FoodDataCached;
+import com.xdw.spiceoflifelatiao.config.ManualFoodConfig;
 import com.xdw.spiceoflifelatiao.util.EatHistory;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.UseAnim;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -15,10 +23,47 @@ import java.util.Optional;
 
 @Mixin(Item.class)
 public class ItemMixin {
-    @Inject(at = @At("HEAD"),method = "getUseDuration")
+    @Inject(at = @At("HEAD"), method = "getUseDuration", cancellable = true)
     public void getUseDurationStart(ItemStack stack, LivingEntity entity, CallbackInfoReturnable<Integer> cir) {
         EatHistory.recentEntity = Optional.ofNullable(entity);
+        if (stack.get(DataComponents.FOOD) != null) return;
+        manualFood(entity == null ? null : entity.level(), stack).ifPresent(food -> cir.setReturnValue(Math.max(1, Math.round(food.eatSeconds() * 20.0F))));
     }
+
+    @Inject(at = @At("HEAD"), method = "getUseAnimation", cancellable = true)
+    public void getUseAnimation(ItemStack stack, CallbackInfoReturnable<UseAnim> cir) {
+        if (stack.get(DataComponents.FOOD) != null) return;
+        if (ConfigCached.ENABLE_MANUAL_FOOD_FILE && ManualFoodConfig.hasAnyEnabledEntry(stack.getItem())) {
+            cir.setReturnValue(UseAnim.EAT);
+        }
+    }
+
+    @Inject(at = @At("HEAD"), method = "use", cancellable = true)
+    public void use(Level level, Player player, InteractionHand hand, CallbackInfoReturnable<InteractionResultHolder<ItemStack>> cir) {
+        ItemStack stack = player.getItemInHand(hand);
+        if (stack.get(DataComponents.FOOD) != null) return;
+        Optional<FoodProperties> food = manualFood(level, stack);
+        if (food.isEmpty()) return;
+
+        if (player.canEat(food.get().canAlwaysEat())) {
+            player.startUsingItem(hand);
+            cir.setReturnValue(InteractionResultHolder.consume(stack));
+        } else {
+            cir.setReturnValue(InteractionResultHolder.fail(stack));
+        }
+    }
+
+    @Inject(
+            method = "finishUsingItem(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/LivingEntity;)Lnet/minecraft/world/item/ItemStack;",
+            at = @At("HEAD"),
+            cancellable = true,
+            require = 0
+    )
+    public void finishManualFood(ItemStack stack, Level level, LivingEntity livingEntity, CallbackInfoReturnable<ItemStack> cir) {
+        if (stack.get(DataComponents.FOOD) != null) return;
+        manualFood(level, stack).ifPresent(food -> cir.setReturnValue(livingEntity.eat(level, stack, food)));
+    }
+
     @Inject(
             method = "finishUsingItem(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/LivingEntity;)Lnet/minecraft/world/item/ItemStack;",
             at = @At("RETURN"),
@@ -27,5 +72,10 @@ public class ItemMixin {
     public void end(ItemStack stack, Level level, LivingEntity livingEntity, CallbackInfoReturnable<ItemStack> cir) {
         FoodDataCached.end();
         FoodDataCached.flag_common = false;
+    }
+
+    private Optional<FoodProperties> manualFood(Level level, ItemStack stack) {
+        if (!ConfigCached.ENABLE_MANUAL_FOOD_FILE) return Optional.empty();
+        return ManualFoodConfig.getFoodProperties(level, stack, null);
     }
 }

--- a/src/main/java/com/xdw/spiceoflifelatiao/mixin/linkage/farmersdelight/FeastBlockMixin.java
+++ b/src/main/java/com/xdw/spiceoflifelatiao/mixin/linkage/farmersdelight/FeastBlockMixin.java
@@ -1,7 +1,6 @@
 package com.xdw.spiceoflifelatiao.mixin.linkage.farmersdelight;
 
 import com.xdw.spiceoflifelatiao.cached.FoodDataCached;
-import com.xdw.spiceoflifelatiao.linkage.farmersdelight.FeastBlockCached;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.ItemInteractionResult;
@@ -18,14 +17,14 @@ public class FeastBlockMixin {
 
     @Inject(at = @At(value = "HEAD"), method = "takeServing")
     public void takeServingStart(LevelAccessor level, BlockPos pos, BlockState state, Player player, InteractionHand hand, CallbackInfoReturnable<ItemInteractionResult> cir) {
-        FeastBlockCached.start();
+        FoodDataCached.startFeastBlockServingCapture();
     }
 
     @Inject(at = @At("RETURN"), method = "takeServing")
     public void takeServingEnd(LevelAccessor level, BlockPos pos, BlockState state, Player player, InteractionHand hand, CallbackInfoReturnable<ItemInteractionResult> cir) {
-        if (cir.getReturnValue() == ItemInteractionResult.SUCCESS && FeastBlockCached.takeServing.isPresent()) {
-            FoodDataCached.usingConvertsTo = FeastBlockCached.takeServing;
+        if (cir.getReturnValue() == ItemInteractionResult.SUCCESS && FoodDataCached.feastBlockTakeServing.isPresent()) {
+            FoodDataCached.usingConvertsTo = FoodDataCached.feastBlockTakeServing;
         }
-        FeastBlockCached.end();
+        FoodDataCached.endFeastBlockServingCapture();
     }
 }

--- a/src/main/java/com/xdw/spiceoflifelatiao/mixin/linkage/farmersdelight/InventoryMixin.java
+++ b/src/main/java/com/xdw/spiceoflifelatiao/mixin/linkage/farmersdelight/InventoryMixin.java
@@ -1,6 +1,6 @@
 package com.xdw.spiceoflifelatiao.mixin.linkage.farmersdelight;
 
-import com.xdw.spiceoflifelatiao.linkage.farmersdelight.FeastBlockCached;
+import com.xdw.spiceoflifelatiao.cached.FoodDataCached;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
@@ -8,13 +8,11 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.Optional;
 
 @Mixin(Inventory.class)
 public class InventoryMixin {
     @Inject(at = @At(value = "HEAD"), method = "add*")
     public void add(int slot, ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
-        if(!FeastBlockCached.flag) return;
-        FeastBlockCached.takeServing = Optional.of(stack.copy());
+        FoodDataCached.captureFeastBlockServing(stack);
     }
 }

--- a/src/main/java/com/xdw/spiceoflifelatiao/network/SyncHandler.java
+++ b/src/main/java/com/xdw/spiceoflifelatiao/network/SyncHandler.java
@@ -26,7 +26,7 @@ public class SyncHandler {
     @SubscribeEvent
     public void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event)
     {
-        syncEatHistory(event.getEntity(),Optional.empty());
+        syncEatHistory(event.getEntity(), Optional.empty());
     }
 
     @SubscribeEvent
@@ -36,12 +36,12 @@ public class SyncHandler {
 
     @SubscribeEvent
     public void onPlayerChangedDimensionEvent(PlayerEvent.PlayerChangedDimensionEvent event){
-        syncEatHistory(event.getEntity(),Optional.empty());
+        syncEatHistory(event.getEntity(), Optional.empty());
     }
 
     @SubscribeEvent
     public void onPlayerRespawnEvent(PlayerEvent.PlayerRespawnEvent event){
-        syncEatHistory(event.getEntity(),Optional.empty());
+        syncEatHistory(event.getEntity(), Optional.empty());
     }
 
     public static void syncEatHistory(Player _oldPlayer, Optional<Player> _newPlayer) {
@@ -57,4 +57,6 @@ public class SyncHandler {
                     });
         }
     }
+
+
 }


### PR DESCRIPTION
我基于当前 fork 对可食用物品识别、手动维护和服务器管理体验做了一组改进。整体目标不是改变原本玩法，而是让服务器可以更稳定、更可控地管理“哪些物品可以吃”，同时保留作者原有的自动识别逻辑。

## 一、改进背景

当前版本在服务器中遇到几个实际问题：

1. 自动计算可食用物品时，偶尔会把本来不可食用的物品识别成可食用，例如原石等普通方块物品。
2. 如果关闭自动计算，又会导致部分 mod 食物无法识别，尤其是本来由其他 mod 自带食物属性或效果的物品。
3. 服主手动添加的可食用物品数据保存位置比较隐蔽，不方便查找、编辑、备份和迁移。
4. 某些情况下，服务器重启或世界数据重新加载后，手动添加的可食用物品可能丢失。
5. 多世界服务器中，缺少方便查看当前世界、所有已加载世界可食用名单的指令。
6. 服主希望能在游戏内直接查看、添加、修改、删除可食用物品配置和对应效果。

因此这次改动主要围绕：

```text
可控性
可维护性
兼容性
不破坏原作者逻辑
```

## 二、核心改动概览

### 1. 新增独立手动可食用配置文件

新增文件：

```text
config/spiceoflifelatiao/edible_items.json
```

用于保存通过指令手动添加或修改的可食用物品配置。

这样服主可以直接找到、备份、编辑、迁移这些配置，不再需要去世界数据或附件数据中查找。

这个文件主要保存：

```text
物品 ID
饱食度
饱和度
食用时间
是否总是可以吃
食用后转换物品
多口食物参数
食用效果列表
```

### 2. 新增手动配置开关

新增配置项：

```toml
enable_manual_food_file = true
```

含义：

```text
true  = 启用新的 JSON 手动可食用物品配置
false = 不启用新的 JSON 手动配置
```

### 3. 新增自动采集开关

新增配置项：

```toml
enable_auto_block_food_collect = true
```

含义：

```text
true  = 保留原本自动计算 / 自动采集可食用物品逻辑
false = 关闭自动采集，主要依赖已有缓存和手动配置
```

这个配置适合不希望自动识别继续误判的服务器。

### 4. 新增可食用物品 ID 安全校验开关

新增配置项：

```toml
enable_food_id_safety_check = true
```

含义：

```text
true  = 启用安全校验。hash 命中后，还要求物品注册名匹配，降低误判风险。
false = 关闭安全校验。保留原本较宽松的 hash 命中逻辑。
```

这个开关的目的是兼顾两类服务器：

1. 希望严格防止原石等非食物误判为可吃。
2. 希望保留原作者较宽松的“命中即认为可食用”玩法。

所以没有写死行为，而是做成配置项。

## 三、指令系统

新增主指令：

```text
/sol_latiao food ...
```

同时提供别名：

```text
/spiceoflifelatiao food ...
```

需要 OP 权限执行。

## 四、查看配置文件位置

```text
/sol_latiao food path
```

用于显示 `edible_items.json` 的实际路径，方便服主定位配置文件。

## 五、查看可食用物品名单

查看当前世界：

```text
/sol_latiao food list current
/sol_latiao food list current <页码>
```

查看所有已加载世界：

```text
/sol_latiao food list all
/sol_latiao food list all <页码>
```

这里的 `all` 指服务器当前已加载的所有世界，适合 Multiverse / mv 多世界服务器使用。

## 六、查看单个物品配置

```text
/sol_latiao food show current <物品ID>
```

示例：

```text
/sol_latiao food show current minecraft:apple
/sol_latiao food show current mekanism_canteen
```

`show` 会显示当前实际生效配置，包括：

```text
饱食度
饱和度
食用时间
是否总是可以吃
食用后转换物品
bites / bitesType / bitesOffset
食用效果
配置来源
```

同时支持带冒号 ID 和下划线别名。

例如：

```text
mekanism:canteen
mekanism_canteen
minecraft:apple
minecraft_apple
```

都会尝试解析为真实注册名。

## 七、添加可食用物品

当前世界添加：

```text
/sol_latiao food add current <物品ID> <饱食度> <饱和度> [食用秒数] [是否总能吃] [食用后转换物品] [bites] [bitesType] [bitesOffset]
```

全局添加：

```text
/sol_latiao food add global <物品ID> <饱食度> <饱和度> [食用秒数] [是否总能吃] [食用后转换物品] [bites] [bitesType] [bitesOffset]
```

简单示例：

```text
/sol_latiao food add current mekanism_canteen 4 0.6
```

带食用时间：

```text
/sol_latiao food add current mekanism_canteen 4 0.6 1.6
```

带“总是可以吃”：

```text
/sol_latiao food add current mekanism_canteen 4 0.6 1.6 true
```

没有转换物品时可写：

```text
none
```

例如：

```text
/sol_latiao food add current mekanism_canteen 4 0.6 1.6 true none
```

## 八、参数说明

### 饱食度 nutrition / hunger / hungry

类型：整数。

推荐范围：

```text
0 ~ 20
```

参考：

```text
苹果：4
面包：5
熟牛排：8
金胡萝卜：6
```

为了方便服主理解，`set` 中同时支持这些别名：

```text
nutrition
hunger
hungry
```

三者都表示饱食度。

### 饱和度 saturation

类型：小数。

推荐范围：

```text
0.0 ~ 2.0
```

它不是直接增加多少金色鸡腿，而是饱和度倍率。

实际恢复大致为：

```text
实际饱和度恢复 = 饱食度 × 饱和度倍率 × 2
```

参考：

```text
苹果：0.3
面包：0.6
熟牛排：0.8
金胡萝卜：1.2
```

### 食用秒数 eatSeconds

类型：小数。

推荐范围：

```text
0.05 ~ 60.0
```

原版常见食用时间约为：

```text
1.6 秒
```

### 是否总能吃 canAlwaysEat

类型：布尔值。

```text
true  = 饱食度满了也能吃
false = 饱食度满了不能吃
```

### 食用后转换物品 usingConvertsTo

例如汤类食物吃完后返回碗：

```text
minecraft:bowl
```

如果没有转换物品，填写：

```text
none
```

### bites

多口食物的口数。

例如：

```text
4
```

表示这个食物有 4 口。

普通食物不需要填写。

### bitesType

多口食物类型。

支持：

```text
bites
bite
0
servings
serving
1
```

一般推荐使用：

```text
bites
```

### bitesOffset

多口食物偏移值，主要给特殊显示或特殊计算使用。

普通情况填：

```text
0
```

多口食物示例：

```text
/sol_latiao food add current farmersdelight_apple_pie 4 0.6 1.6 true none 4 bites 0
```

## 九、修改物品属性

```text
/sol_latiao food set current <物品ID> nutrition <值>
/sol_latiao food set current <物品ID> hunger <值>
/sol_latiao food set current <物品ID> hungry <值>
/sol_latiao food set current <物品ID> saturation <值>
/sol_latiao food set current <物品ID> eatSeconds <值>
/sol_latiao food set current <物品ID> canAlwaysEat <true|false>
/sol_latiao food set current <物品ID> usingConvertsTo <物品ID或none>
/sol_latiao food set current <物品ID> bites <值>
/sol_latiao food set current <物品ID> bitesType <值>
/sol_latiao food set current <物品ID> bitesOffset <值>
```

示例：

```text
/sol_latiao food set current mekanism_canteen hunger 6
/sol_latiao food set current mekanism_canteen saturation 0.8
/sol_latiao food set current mekanism_canteen canAlwaysEat true
/sol_latiao food set current mekanism_canteen usingConvertsTo minecraft:bowl
```

## 十、管理食用效果

添加效果：

```text
/sol_latiao food effect add current <物品ID> <效果ID> <持续tick> <等级> [概率]
```

示例：

```text
/sol_latiao food effect add current mekanism_canteen minecraft_regeneration 200 1 1.0
```

说明：

```text
20 tick = 1 秒
等级 amplifier：0 表示 I，1 表示 II
概率：0.0 ~ 1.0
```

删除某个效果：

```text
/sol_latiao food effect remove current <物品ID> <效果ID>
```

清空该物品所有效果：

```text
/sol_latiao food effect clear current <物品ID>
```

## 十一、删除配置

```text
/sol_latiao food remove current <物品ID>
```

示例：

```text
/sol_latiao food remove current mekanism_canteen
```

## 十二、保存与重载

保存：

```text
/sol_latiao food save
```

重载：

```text
/sol_latiao food reload
```

## 十三、导入旧数据

为了兼容已有服务器，提供从旧世界附件数据导入到 JSON 的指令。

导入当前世界：

```text
/sol_latiao food importLegacy current
```

导入所有已加载世界：

```text
/sol_latiao food importLegacy all
```

已有服务器升级后建议执行：

```text
/sol_latiao food importLegacy all
/sol_latiao food save
```

## 十四、与原作者逻辑的兼容

这次改动尽量保留原作者原本行为：

1. 不删除原本自动识别逻辑。
2. 不强制关闭 hash 命中逻辑，而是新增安全校验开关。
3. 不强制修改原有联动 mixin warning 逻辑。
4. Farmer’s Delight、Jade 等原有联动尽量继续走原作者已有链路。
5. 手动 JSON 配置作为覆盖层，不应清空原版或其他 mod 自带的 FOOD 组件。

也就是说，手动配置的优先级是：

```text
有手动配置：使用手动配置
没有手动配置：保留原版 / 其他 mod 原本 FoodProperties
```

这个点很重要，避免出现“原版食物和其他 mod 食物不能吃，只有手动添加的能吃”的问题。

## 十五、Jade 显示兼容思路

手动添加 / 修改 / 删除食物配置后，会尽量同步写入原作者的 `LevelOrgFoodValue` 世界附件数据。

这样 Jade 仍然可以继续使用作者原本的世界附件显示逻辑，而不需要额外重写 Jade 联动。

需要注意：

```text
Jade 原本主要是看向世界里的方块 / 方块食物时显示信息。
背包里的物品 tooltip 不一定由 Jade 负责显示。
```

所以“物品能吃”和“Jade 一定显示物品 tooltip”不是同一个链路。

## 十六、已修复的问题

开发和测试过程中发现并修复了这些问题：

1. Java lambda 捕获非 final 变量导致编译失败。
2. `FoodProperties.PossibleEffect` 直接传入 `MobEffectInstance` 的构造器不可用，改为使用 `Supplier<MobEffectInstance>`。
3. `Optional<FoodProperties>` 与 `FoodProperties` 类型不匹配。
4. 自定义 Brigadier 参数类型未注册，导致命令树同步给客户端时报错，改回原版可同步参数类型。
5. `mekanism:canteen` 这类带冒号的物品 ID 在指令中不好输入或被解析失败，增加下划线别名解析。
6. Farmer’s Delight 联动中 `FeastBlockCached` 缺失可能导致玩家捡物品时崩溃，已调整缓存位置，避免运行时类缺失。
7. 手动配置不应覆盖掉原版或其他 mod 自带食物属性，已修复为“仅有手动条目时才覆盖”。

## 十七、推荐配置

如果服务器希望尽量避免自动识别误判，推荐：

```toml
enable_auto_block_food_collect = false
enable_manual_food_file = true
enable_food_id_safety_check = true
```

如果服务器希望保留原作者较宽松玩法，推荐：

```toml
enable_auto_block_food_collect = true
enable_manual_food_file = true
enable_food_id_safety_check = false
```

如果服务器希望继续自动识别，但尽量减少误判，推荐：

```toml
enable_auto_block_food_collect = true
enable_manual_food_file = true
enable_food_id_safety_check = true
```

## 十八、整体总结

这组改动的主要目的，是让可食用物品系统从“自动识别为主、数据较难维护”变成：

```text
自动识别仍然可用
手动配置更清晰
误判行为可控制
多世界可查看
游戏内可管理
配置文件可备份和迁移
```

同时尽量不破坏作者原本的自动识别和联动设计。
